### PR TITLE
Fix groups example

### DIFF
--- a/demo/example.py
+++ b/demo/example.py
@@ -160,10 +160,9 @@ def run_groups_example(client):
     - Remove a member from a group
     - Delete a Group
     """
-    original_groups = client.groups()
-
     try:
         # First delete group if it already exists
+        original_groups = client.groups()
         _delete_leftover_group(original_groups, 'box_sdk_demo_group')
         _delete_leftover_group(original_groups, 'renamed_box_sdk_demo_group')
 


### PR DESCRIPTION
If the demo user does not have permissions to be in groups, then the
initial :meth:`Client.groups()` call in :func:`run_groups_example()`
will fail.

Move this call inside the try-block to have this example get skipped
when the user does not have the correct permissions.
