### PR TITLE
Return bool from `Item.remove_shared_link()`.

### DIFF
--- a/boxsdk/object/item.py
+++ b/boxsdk/object/item.py
@@ -200,7 +200,7 @@ class Item(BaseObject):
         """
         data = {'shared_link': None}
         item = self.update_info(data, etag=etag)
-        return item.shared_link['url']
+        return item.shared_link is None
 
     def delete(self, params=None, etag=None):
         """Delete the item.

--- a/test/unit/object/test_item.py
+++ b/test/unit/object/test_item.py
@@ -83,15 +83,15 @@ def test_remove_shared_link(test_item_and_response, mock_box_session, etag, if_m
     # pylint:disable=redefined-outer-name, protected-access
     test_item, _ = test_item_and_response
     expected_url = test_item.get_url()
-    mock_box_session.put.return_value.json.return_value = {'shared_link': {'url': None}}
-    url = test_item.remove_shared_link(etag=etag)
+    mock_box_session.put.return_value.json.return_value = {'shared_link': None}
+    removed = test_item.remove_shared_link(etag=etag)
     mock_box_session.put.assert_called_once_with(
         expected_url,
         data=json.dumps({'shared_link': None}),
         headers=if_match_header,
         params=None,
     )
-    assert url is None
+    assert removed is True
 
 
 @pytest.mark.parametrize('fields', (None, ['name', 'created_at']))


### PR DESCRIPTION
Make the return type match the type specified in the docstring.  The
method was previously attempting to return ``unicode or None``.

The method was also previously attempting to access the 'url' item on
the shared_link object. However, the Box API returns a null object when
the shared link is disabled [1]. Make the method check for success by
doing an ``is None`` check on the shared_link object.

[1] https://box-content.readme.io/#create-a-shared-link-for-a-folder