### PR TITLE
Correct test invocations of Client.folder()

### DIFF
--- a/test/functional/test_rate_limits.py
+++ b/test/functional/test_rate_limits.py
@@ -5,6 +5,6 @@ from __future__ import unicode_literals
 
 def test_too_many_requests_causes_retry(box_client, mock_box, monkeypatch):
     monkeypatch.setattr(mock_box, 'RATE_LIMIT_THRESHOLD', 1)
-    box_client.folder(0).get()
-    box_client.folder(0).get()
+    box_client.folder('0').get()
+    box_client.folder('0').get()
     assert len(mock_box.requests) == 6  # 3 auth requests, 2 real requests, and a retry

--- a/test/functional/test_recovery.py
+++ b/test/functional/test_recovery.py
@@ -48,7 +48,7 @@ def test_client_retries_on_server_error(box_client, mock_box, error_code, should
     # pylint:disable=redefined-outer-name
     should_apply, expected_num_requests = should_apply
     mock_box.get_folder_info.add_chaos(error(error_code), should_apply)
-    box_client.folder(0).get()
+    box_client.folder('0').get()
     assert len(mock_box.requests) == expected_num_requests
 
 
@@ -56,7 +56,7 @@ def test_client_retries_on_retry_after(box_client, mock_box, retry_code, should_
     # pylint:disable=redefined-outer-name
     should_apply, expected_num_requests = should_apply
     mock_box.get_folder_info.add_chaos(error(retry_code, headers={RETRY_AFTER_HEADER: 1}), should_apply)
-    box_client.folder(0).get()
+    box_client.folder('0').get()
     assert len(mock_box.requests) == expected_num_requests
 
 
@@ -64,7 +64,7 @@ def test_client_stops_retrying_after_10_server_errors(box_client, mock_box, erro
     # pylint:disable=redefined-outer-name
     mock_box.get_folder_info.add_chaos(error(error_code))
     with pytest.raises(BoxAPIException) as exc_info:
-        box_client.folder(0).get()
+        box_client.folder('0').get()
         assert exc_info.value.status == error_code
     assert len(mock_box.requests) == 14  # 3 auth requests, 1 try, and 10 retries
 
@@ -74,7 +74,7 @@ def test_non_json_response_raises(box_client, mock_box, chaos):
     # pylint:disable=redefined-outer-name
     mock_box.get_folder_info.add_chaos(chaos)
     with pytest.raises(BoxAPIException) as exc_info:
-        box_client.folder(0).get()
+        box_client.folder('0').get()
         assert exc_info.value.status == 200
         assert 'json' in exc_info.value.message
 

--- a/test/functional/test_token_refresh.py
+++ b/test/functional/test_token_refresh.py
@@ -9,7 +9,7 @@ def test_expired_access_token_is_refreshed(box_oauth, box_client, mock_box):
     # pylint:disable=protected-access
     mock_box.oauth.expire_token(box_oauth._access_token)
     # pylint:enable=protected-access
-    box_client.folder(0).get()
+    box_client.folder('0').get()
     assert len(mock_box.requests) == 6  # GET /authorize, POST /authorize, /token, get_info, refresh /token, get_info
 
 
@@ -19,4 +19,4 @@ def test_expired_refresh_token_raises(box_oauth, box_client, mock_box):
     mock_box.oauth.expire_token(box_oauth._refresh_token)
     # pylint:enable=protected-access
     with pytest.raises(BoxOAuthException):
-        box_client.folder(0).get()
+        box_client.folder('0').get()

--- a/test/integration/test_retry_and_refresh.py
+++ b/test/integration/test_retry_and_refresh.py
@@ -17,7 +17,7 @@ def test_automatic_refresh(
         successful_token_response,
         generic_successful_response,
     ]
-    box_client.folder(0).get()
+    box_client.folder('0').get()
     assert mock_box_network.session.request.mock_calls == [
         call(
             'GET',


### PR DESCRIPTION
Some tests were calling `Client.folder()` with a `folder_id` argument of 0. However, that parameter is supposed to be of type `unicode`, not `int`.

Correct all occurrences of `folder(0)` to `folder('0')`.