### PR TITLE
Add support for As-User and shared items headers.

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,14 @@
 Release History
 ---------------
 
+Upcoming
+++++++++
+
+- Added support for 'As-User' requests. See https://box-content.readme.io/#as-user-1
+- Improved support for accessing shared items. Items returned from the `client.get_shared_item` method will
+  remember the shared link (and the optionally provided shared link password) so methods called on the returned
+  items will be properly authorized.
+
 1.1.7 (2015-05-28)
 ++++++++++++++++++
 
@@ -12,7 +20,7 @@ Release History
 
 - ``Item.remove_shared_link()`` was trying to return an incorrect (according to its own documentation) value, and was
   also attempting to calculate that value in a way that made an incorrect assumption about the API response. The latter
-  problem caused invokations of the method to raise TypeError. The method now handles the response correctly, and
+  problem caused invocations of the method to raise TypeError. The method now handles the response correctly, and
   correctly returns type ``bool``.
 
 1.1.6 (2015-04-17)

--- a/README.rst
+++ b/README.rst
@@ -205,6 +205,26 @@ Metadata
     update.add('/key', 'new_value')
     metadata.update(update)
 
+As-User
+~~~~~~~
+
+The `Client` class and all Box objects also have an `as_user` method.
+
+`as-user` returns a copy of the object on which it was called that will make Box API requests
+as though the specified user was making it.
+
+See https://box-content.readme.io/#as-user-1 for more information about how this works via the Box API.
+
+.. code-block:: python
+
+    # Logged in as admin, but rename a file as SOME USER
+    user = client.user(user_id='SOME_USER_ID')
+    client.as_user(user).file(file_id='SOME_FILE_ID').rename('bar-2.txt')
+
+
+    # Same thing, but using file's as_user method
+    client.file(file_id='SOME_FILE_ID').as_user(user).rename('bar-2.txt')
+
 
 Contributing
 ------------

--- a/boxsdk/client.py
+++ b/boxsdk/client.py
@@ -13,12 +13,13 @@ from .object.events import Events
 from .object.file import File
 from .object.group import Group
 from .object.group_membership import GroupMembership
+from .util.shared_link import get_shared_link_header
 from .util.translator import Translator
 
 
 class Client(object):
 
-    def __init__(self, oauth, network_layer=None):
+    def __init__(self, oauth, network_layer=None, session=None):
         """
         :param oauth:
             OAuth2 object used by the session to authorize requests.
@@ -28,9 +29,15 @@ class Client(object):
             The Network layer to use. If none is provided then an instance of :class:`DefaultNetwork` will be used.
         :type network_layer:
             :class:`Network`
+        :param session:
+            The session object to use. If None is provided then an instance of :class:`BoxSession` will be used.
+        :type session:
+            :class:`BoxSession`
         """
         network_layer = network_layer or DefaultNetwork()
-        self._session = BoxSession(oauth=oauth, network_layer=network_layer)
+        self._oauth = oauth
+        self._network = network_layer
+        self._session = session or BoxSession(oauth=oauth, network_layer=network_layer)
 
     def folder(self, folder_id):
         """
@@ -223,14 +230,16 @@ class Client(object):
         :raises:
             :class:`BoxAPIException` if current user doesn't have permissions to view the shared link.
         """
-        shared_link_password = '&shared_link_password={0}'.format(password) if password is not None else ''
-        box_api_header = 'shared_link={0}{1}'.format(shared_link, shared_link_password)
         response = self.make_request(
             'GET',
             '{0}/shared_items'.format(API.BASE_API_URL),
-            headers={'BoxApi': box_api_header},
+            headers=get_shared_link_header(shared_link, password),
         ).json()
-        return Translator().translate(response['type'])(self._session, response['id'], response)
+        return Translator().translate(response['type'])(
+            self._session.with_shared_link(shared_link, password),
+            response['id'],
+            response,
+        )
 
     def make_request(self, method, url, **kwargs):
         """
@@ -252,3 +261,33 @@ class Client(object):
             :class:`BoxAPIException`
         """
         return self._session.request(method, url, **kwargs)
+
+    def as_user(self, user):
+        """
+        Returns a new client object with default headers set up to make requests as the specified user.
+
+        :param user:
+            The user to impersonate when making API requests.
+        :type user:
+            :class:`User`
+        """
+        return self.__class__(self._oauth, self._network, self._session.as_user(user))
+
+    def with_shared_link(self, shared_link, shared_link_password):
+        """
+        Returns a new client object with default headers set up to make requests using the shared link for auth.
+
+        :param shared_link:
+            The shared link.
+        :type shared_link:
+            `unicode`
+        :param shared_link_password:
+            The password for the shared link.
+        :type shared_link_password:
+            `unicode`
+        """
+        return self.__class__(
+            self._oauth,
+            self._network,
+            self._session.with_shared_link(shared_link, shared_link_password),
+        )

--- a/boxsdk/object/base_endpoint.py
+++ b/boxsdk/object/base_endpoint.py
@@ -50,7 +50,7 @@ class BaseEndpoint(object):
 
     def with_shared_link(self, shared_link, shared_link_password):
         """
-        Returns a new session object with default headers set up to make requests using the shared link for auth.
+        Returns a new endpoint object with default headers set up to make requests using the shared link for auth.
 
         :param shared_link:
             The shared link.

--- a/boxsdk/object/base_endpoint.py
+++ b/boxsdk/object/base_endpoint.py
@@ -36,3 +36,29 @@ class BaseEndpoint(object):
         url = ['{0}/{1}'.format(API.BASE_API_URL, endpoint)]
         url.extend(['/{0}'.format(x) for x in args])
         return ''.join(url)
+
+    def as_user(self, user):
+        """
+        Returns a new endpoint object with default headers set up to make requests as the specified user.
+
+        :param user:
+            The user to impersonate when making API requests.
+        :type user:
+            :class:`User`
+        """
+        return self.__class__(self._session.as_user(user))
+
+    def with_shared_link(self, shared_link, shared_link_password):
+        """
+        Returns a new session object with default headers set up to make requests using the shared link for auth.
+
+        :param shared_link:
+            The shared link.
+        :type shared_link:
+            `unicode`
+        :param shared_link_password:
+            The password for the shared link.
+        :type shared_link_password:
+            `unicode`
+        """
+        return self.__class__(self._session.with_shared_link(shared_link, shared_link_password))

--- a/boxsdk/object/base_object.py
+++ b/boxsdk/object/base_object.py
@@ -232,3 +232,15 @@ class BaseObject(BaseEndpoint):
             current_index += limit
             if current_index >= response['total_count']:
                 break
+
+    def as_user(self, user):
+        """ Base class override. """
+        return self.__class__(self._session.as_user(user), self._object_id, self._response_object)
+
+    def with_shared_link(self, shared_link, shared_link_password):
+        """ Base class override. """
+        return self.__class__(
+            self._session.with_shared_link(shared_link, shared_link_password),
+            self._object_id,
+            self._response_object,
+        )

--- a/boxsdk/object/group_membership.py
+++ b/boxsdk/object/group_membership.py
@@ -74,3 +74,23 @@ class GroupMembership(BaseObject):
         group = group or Translator().translate(group_info['type'])(session, group_info['id'], group_info)
 
         return user, group
+
+    def as_user(self, user):
+        """ Base class override. """
+        return self.__class__(
+            self._session.as_user(user),
+            self._object_id,
+            self._response_object,
+            self.user,
+            self.group,
+        )
+
+    def with_shared_link(self, shared_link, shared_link_password):
+        """ Base class override. """
+        return self.__class__(
+            self._session.with_shared_link(shared_link, shared_link_password),
+            self._object_id,
+            self._response_object,
+            self.user,
+            self.group,
+        )

--- a/boxsdk/object/metadata.py
+++ b/boxsdk/object/metadata.py
@@ -123,6 +123,7 @@ class Metadata(BaseEndpoint):
         self._template = template
 
     def get_url(self, *args):
+        """ Base class override. """
         return self._object.get_url('metadata', self._scope, self._template)
 
     @staticmethod
@@ -197,3 +198,16 @@ class Metadata(BaseEndpoint):
             data=json.dumps(metadata),
             headers={b'Content-Type': b'application/json'},
         ).json()
+
+    def as_user(self, user):
+        """ Base class override. """
+        return self.__class__(self._session.as_user(user), self._object, self._scope, self._template)
+
+    def with_shared_link(self, shared_link, shared_link_password):
+        """ Base class override. """
+        return self.__class__(
+            self._session.with_shared_link(shared_link, shared_link_password),
+            self._object,
+            self._scope,
+            self._template
+        )

--- a/boxsdk/util/shared_link.py
+++ b/boxsdk/util/shared_link.py
@@ -1,0 +1,25 @@
+# coding: utf-8
+
+from __future__ import unicode_literals
+
+
+def get_shared_link_header(shared_link, password=None):
+    """
+    Gets the HTTP header required to use a shared link to grant access to a shared item.
+
+    :param shared_link:
+        The shared link.
+    :type shared_link:
+        `unicode`
+    :param password:
+        The password for the shared link.
+    :type password:
+        `unicode`
+    :return:
+        The item referred to by the shared link.
+    :rtype:
+        :class:`Item`
+    """
+    shared_link_password = '&shared_link_password={0}'.format(password) if password is not None else ''
+    box_api_header = 'shared_link={0}{1}'.format(shared_link, shared_link_password)
+    return {'BoxApi': box_api_header}

--- a/docs/source/boxsdk.util.rst
+++ b/docs/source/boxsdk.util.rst
@@ -20,6 +20,14 @@ boxsdk.util.ordered_dict module
     :undoc-members:
     :show-inheritance:
 
+boxsdk.util.shared_link module
+------------------------------
+
+.. automodule:: boxsdk.util.shared_link
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 boxsdk.util.singleton module
 ----------------------------
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -144,3 +144,18 @@ def update_file_content(test_file_content):
 @pytest.fixture()
 def test_file_path():
     return 'path/to/file'
+
+
+@pytest.fixture(scope='module')
+def mock_object_id():
+    return '42'
+
+
+@pytest.fixture(scope='module')
+def mock_user_id():
+    return 'fake-user-100'
+
+
+@pytest.fixture(scope='module')
+def mock_group_id():
+    return 'fake-group-99'

--- a/test/integration/conftest.py
+++ b/test/integration/conftest.py
@@ -28,7 +28,7 @@ def box_oauth(mock_box_network, client_id, client_secret, access_token, refresh_
     )
 
 
-@pytest.fixture(scope='module')
+@pytest.fixture()
 def mock_box_network():
     return MockNetwork()
 

--- a/test/integration/test_as_user.py
+++ b/test/integration/test_as_user.py
@@ -9,7 +9,7 @@ from boxsdk.object.user import User
 
 
 @pytest.fixture
-def box_api_headers(mock_user_id, access_token):
+def as_user_headers(mock_user_id, access_token):
     return {'Authorization': 'Bearer {0}'.format(access_token), 'As-User': mock_user_id}
 
 
@@ -18,18 +18,16 @@ def test_client_as_user_causes_as_user_header_to_be_added(
         mock_box_network,
         generic_successful_response,
         mock_user_id,
-        box_api_headers,
+        as_user_headers,
 ):
     # pylint:disable=redefined-outer-name
-    mock_box_network.session.request.side_effect = [
-        generic_successful_response,
-    ]
+    mock_box_network.session.request.side_effect = [generic_successful_response]
     box_client.as_user(User(None, mock_user_id)).folder('0').get()
     assert mock_box_network.session.request.mock_calls == [
         call(
             'GET',
             '{0}/folders/0'.format(API.BASE_API_URL),
-            headers=box_api_headers,
+            headers=as_user_headers,
             params=None,
         ),
     ]
@@ -40,7 +38,7 @@ def test_folder_object_as_user_causes_as_user_header_to_be_added(
         mock_box_network,
         generic_successful_response,
         mock_user_id,
-        box_api_headers,
+        as_user_headers,
 ):
     # pylint:disable=redefined-outer-name
     mock_box_network.session.request.side_effect = [
@@ -51,7 +49,7 @@ def test_folder_object_as_user_causes_as_user_header_to_be_added(
         call(
             'GET',
             '{0}/folders/0'.format(API.BASE_API_URL),
-            headers=box_api_headers,
+            headers=as_user_headers,
             params=None,
         ),
     ]
@@ -62,7 +60,7 @@ def test_group_membership_object_as_user_causes_as_user_header_to_be_added(
         mock_box_network,
         generic_successful_response,
         mock_user_id,
-        box_api_headers,
+        as_user_headers,
 ):
     # pylint:disable=redefined-outer-name
     mock_box_network.session.request.side_effect = [
@@ -75,7 +73,7 @@ def test_group_membership_object_as_user_causes_as_user_header_to_be_added(
         call(
             'GET',
             '{0}/group_memberships/0'.format(API.BASE_API_URL),
-            headers=box_api_headers,
+            headers=as_user_headers,
             params=None,
         ),
     ]
@@ -86,7 +84,7 @@ def test_events_endpoint_as_user_causes_as_user_header_to_be_added(
         mock_box_network,
         generic_successful_response,
         mock_user_id,
-        box_api_headers,
+        as_user_headers,
 ):
     # pylint:disable=redefined-outer-name
     mock_box_network.session.request.side_effect = [
@@ -99,7 +97,7 @@ def test_events_endpoint_as_user_causes_as_user_header_to_be_added(
         call(
             'GET',
             options['url'],
-            headers=box_api_headers,
+            headers=as_user_headers,
             timeout=options['retry_timeout'],
             params={'stream_position': stream_position},
         ),
@@ -111,7 +109,7 @@ def test_metadata_endpoint_as_user_causes_as_user_header_to_be_added(
         mock_box_network,
         generic_successful_response,
         mock_user_id,
-        box_api_headers,
+        as_user_headers,
 ):
     # pylint:disable=redefined-outer-name
     mock_box_network.session.request.side_effect = [
@@ -122,6 +120,6 @@ def test_metadata_endpoint_as_user_causes_as_user_header_to_be_added(
         call(
             'GET',
             '{0}/files/0/metadata/global/properties'.format(API.BASE_API_URL),
-            headers=box_api_headers,
+            headers=as_user_headers,
         ),
     ]

--- a/test/integration/test_as_user.py
+++ b/test/integration/test_as_user.py
@@ -2,9 +2,15 @@
 
 from __future__ import unicode_literals
 from mock import call, patch
+import pytest
 from boxsdk.config import API
 from boxsdk.object.group_membership import GroupMembership
 from boxsdk.object.user import User
+
+
+@pytest.fixture
+def box_api_headers(mock_user_id, access_token):
+    return {'Authorization': 'Bearer {0}'.format(access_token), 'As-User': mock_user_id}
 
 
 def test_client_as_user_causes_as_user_header_to_be_added(
@@ -12,8 +18,9 @@ def test_client_as_user_causes_as_user_header_to_be_added(
         mock_box_network,
         generic_successful_response,
         mock_user_id,
-        access_token,
+        box_api_headers,
 ):
+    # pylint:disable=redefined-outer-name
     mock_box_network.session.request.side_effect = [
         generic_successful_response,
     ]
@@ -22,7 +29,7 @@ def test_client_as_user_causes_as_user_header_to_be_added(
         call(
             'GET',
             '{0}/folders/0'.format(API.BASE_API_URL),
-            headers={'Authorization': 'Bearer {}'.format(access_token), 'As-User': mock_user_id},
+            headers=box_api_headers,
             params=None,
         ),
     ]
@@ -33,8 +40,9 @@ def test_folder_object_as_user_causes_as_user_header_to_be_added(
         mock_box_network,
         generic_successful_response,
         mock_user_id,
-        access_token,
+        box_api_headers,
 ):
+    # pylint:disable=redefined-outer-name
     mock_box_network.session.request.side_effect = [
         generic_successful_response,
     ]
@@ -43,7 +51,7 @@ def test_folder_object_as_user_causes_as_user_header_to_be_added(
         call(
             'GET',
             '{0}/folders/0'.format(API.BASE_API_URL),
-            headers={'Authorization': 'Bearer {}'.format(access_token), 'As-User': mock_user_id},
+            headers=box_api_headers,
             params=None,
         ),
     ]
@@ -54,8 +62,9 @@ def test_group_membership_object_as_user_causes_as_user_header_to_be_added(
         mock_box_network,
         generic_successful_response,
         mock_user_id,
-        access_token,
+        box_api_headers,
 ):
+    # pylint:disable=redefined-outer-name
     mock_box_network.session.request.side_effect = [
         generic_successful_response,
     ]
@@ -66,7 +75,7 @@ def test_group_membership_object_as_user_causes_as_user_header_to_be_added(
         call(
             'GET',
             '{0}/group_memberships/0'.format(API.BASE_API_URL),
-            headers={'Authorization': 'Bearer {}'.format(access_token), 'As-User': mock_user_id},
+            headers=box_api_headers,
             params=None,
         ),
     ]
@@ -77,8 +86,9 @@ def test_events_endpoint_as_user_causes_as_user_header_to_be_added(
         mock_box_network,
         generic_successful_response,
         mock_user_id,
-        access_token,
+        box_api_headers,
 ):
+    # pylint:disable=redefined-outer-name
     mock_box_network.session.request.side_effect = [
         generic_successful_response,
     ]
@@ -89,7 +99,7 @@ def test_events_endpoint_as_user_causes_as_user_header_to_be_added(
         call(
             'GET',
             options['url'],
-            headers={'Authorization': 'Bearer {}'.format(access_token), 'As-User': mock_user_id},
+            headers=box_api_headers,
             timeout=options['retry_timeout'],
             params={'stream_position': stream_position},
         ),
@@ -101,8 +111,9 @@ def test_metadata_endpoint_as_user_causes_as_user_header_to_be_added(
         mock_box_network,
         generic_successful_response,
         mock_user_id,
-        access_token,
+        box_api_headers,
 ):
+    # pylint:disable=redefined-outer-name
     mock_box_network.session.request.side_effect = [
         generic_successful_response,
     ]
@@ -111,6 +122,6 @@ def test_metadata_endpoint_as_user_causes_as_user_header_to_be_added(
         call(
             'GET',
             '{0}/files/0/metadata/global/properties'.format(API.BASE_API_URL),
-            headers={'Authorization': 'Bearer {}'.format(access_token), 'As-User': mock_user_id},
+            headers=box_api_headers,
         ),
     ]

--- a/test/integration/test_as_user.py
+++ b/test/integration/test_as_user.py
@@ -1,0 +1,116 @@
+# coding: utf-8
+
+from __future__ import unicode_literals
+from mock import call, patch
+from boxsdk.config import API
+from boxsdk.object.group_membership import GroupMembership
+from boxsdk.object.user import User
+
+
+def test_client_as_user_causes_as_user_header_to_be_added(
+        box_client,
+        mock_box_network,
+        generic_successful_response,
+        mock_user_id,
+        access_token,
+):
+    mock_box_network.session.request.side_effect = [
+        generic_successful_response,
+    ]
+    box_client.as_user(User(None, mock_user_id)).folder('0').get()
+    assert mock_box_network.session.request.mock_calls == [
+        call(
+            'GET',
+            '{0}/folders/0'.format(API.BASE_API_URL),
+            headers={'Authorization': 'Bearer {}'.format(access_token), 'As-User': mock_user_id},
+            params=None,
+        ),
+    ]
+
+
+def test_folder_object_as_user_causes_as_user_header_to_be_added(
+        box_client,
+        mock_box_network,
+        generic_successful_response,
+        mock_user_id,
+        access_token,
+):
+    mock_box_network.session.request.side_effect = [
+        generic_successful_response,
+    ]
+    box_client.folder('0').as_user(User(None, mock_user_id)).get()
+    assert mock_box_network.session.request.mock_calls == [
+        call(
+            'GET',
+            '{0}/folders/0'.format(API.BASE_API_URL),
+            headers={'Authorization': 'Bearer {}'.format(access_token), 'As-User': mock_user_id},
+            params=None,
+        ),
+    ]
+
+
+def test_group_membership_object_as_user_causes_as_user_header_to_be_added(
+        box_client,
+        mock_box_network,
+        generic_successful_response,
+        mock_user_id,
+        access_token,
+):
+    mock_box_network.session.request.side_effect = [
+        generic_successful_response,
+    ]
+    with patch.object(GroupMembership, '_init_user_and_group_instances') as init:
+        init.return_value = None, None
+        box_client.group_membership('0').as_user(User(None, mock_user_id)).get()
+    assert mock_box_network.session.request.mock_calls == [
+        call(
+            'GET',
+            '{0}/group_memberships/0'.format(API.BASE_API_URL),
+            headers={'Authorization': 'Bearer {}'.format(access_token), 'As-User': mock_user_id},
+            params=None,
+        ),
+    ]
+
+
+def test_events_endpoint_as_user_causes_as_user_header_to_be_added(
+        box_client,
+        mock_box_network,
+        generic_successful_response,
+        mock_user_id,
+        access_token,
+):
+    mock_box_network.session.request.side_effect = [
+        generic_successful_response,
+    ]
+    stream_position = 1348790499819
+    options = {'url': '{0}/events'.format(API.BASE_API_URL), 'retry_timeout': 60}
+    box_client.events().as_user(User(None, mock_user_id)).long_poll(options, stream_position)
+    assert mock_box_network.session.request.mock_calls == [
+        call(
+            'GET',
+            options['url'],
+            headers={'Authorization': 'Bearer {}'.format(access_token), 'As-User': mock_user_id},
+            timeout=options['retry_timeout'],
+            params={'stream_position': stream_position},
+        ),
+    ]
+
+
+def test_metadata_endpoint_as_user_causes_as_user_header_to_be_added(
+        box_client,
+        mock_box_network,
+        generic_successful_response,
+        mock_user_id,
+        access_token,
+):
+    mock_box_network.session.request.side_effect = [
+        generic_successful_response,
+    ]
+    box_client.file('0').metadata().as_user(User(None, mock_user_id)).get()
+    assert mock_box_network.session.request.mock_calls == [
+        call(
+            'GET',
+            '{0}/files/0/metadata/global/properties'.format(API.BASE_API_URL),
+            headers={'Authorization': 'Bearer {}'.format(access_token), 'As-User': mock_user_id},
+        ),
+    ]

--- a/test/integration/test_with_shared_link.py
+++ b/test/integration/test_with_shared_link.py
@@ -1,0 +1,141 @@
+# coding: utf-8
+
+from __future__ import unicode_literals
+from mock import call, patch
+import pytest
+from boxsdk.config import API
+from boxsdk.object.group_membership import GroupMembership
+from boxsdk.util.shared_link import get_shared_link_header
+
+
+@pytest.fixture
+def shared_link():
+    return 'https://app.box.com/s/q2i1024dvguiads6mzj2avsq9hmz43du'
+
+
+@pytest.fixture(params=(None, 'shared_link_password'))
+def shared_link_password(request):
+    return request.param
+
+
+@pytest.fixture
+def box_api_header(shared_link, shared_link_password):
+    return get_shared_link_header(shared_link, shared_link_password)['BoxApi']
+
+def test_client_with_shared_link_causes_box_api_header_to_be_added(
+        box_client,
+        mock_box_network,
+        generic_successful_response,
+        shared_link,
+        shared_link_password,
+        box_api_header,
+        access_token,
+):
+    mock_box_network.session.request.side_effect = [
+        generic_successful_response,
+    ]
+    box_client.with_shared_link(shared_link, shared_link_password).folder('0').get()
+    assert mock_box_network.session.request.mock_calls == [
+        call(
+            'GET',
+            '{0}/folders/0'.format(API.BASE_API_URL),
+            headers={'Authorization': 'Bearer {}'.format(access_token), 'BoxApi': box_api_header},
+            params=None,
+        ),
+    ]
+
+
+def test_folder_object_with_shared_link_causes_box_api_header_to_be_added(
+        box_client,
+        mock_box_network,
+        generic_successful_response,
+        shared_link,
+        shared_link_password,
+        box_api_header,
+        access_token,
+):
+    mock_box_network.session.request.side_effect = [
+        generic_successful_response,
+    ]
+    box_client.folder('0').with_shared_link(shared_link, shared_link_password).get()
+    assert mock_box_network.session.request.mock_calls == [
+        call(
+            'GET',
+            '{0}/folders/0'.format(API.BASE_API_URL),
+            headers={'Authorization': 'Bearer {}'.format(access_token), 'BoxApi': box_api_header},
+            params=None,
+        ),
+    ]
+
+
+def test_group_membership_object_with_shared_link_causes_box_api_header_to_be_added(
+        box_client,
+        mock_box_network,
+        generic_successful_response,
+        shared_link,
+        shared_link_password,
+        box_api_header,
+        access_token,
+):
+    mock_box_network.session.request.side_effect = [
+        generic_successful_response,
+    ]
+    with patch.object(GroupMembership, '_init_user_and_group_instances') as init:
+        init.return_value = None, None
+        box_client.group_membership('0').with_shared_link(shared_link, shared_link_password).get()
+    assert mock_box_network.session.request.mock_calls == [
+        call(
+            'GET',
+            '{0}/group_memberships/0'.format(API.BASE_API_URL),
+            headers={'Authorization': 'Bearer {}'.format(access_token), 'BoxApi': box_api_header},
+            params=None,
+        ),
+    ]
+
+
+def test_events_endpoint_with_shared_link_causes_box_api_header_to_be_added(
+        box_client,
+        mock_box_network,
+        generic_successful_response,
+        shared_link,
+        shared_link_password,
+        box_api_header,
+        access_token,
+):
+    mock_box_network.session.request.side_effect = [
+        generic_successful_response,
+    ]
+    stream_position = 1348790499819
+    options = {'url': '{0}/events'.format(API.BASE_API_URL), 'retry_timeout': 60}
+    box_client.events().with_shared_link(shared_link, shared_link_password).long_poll(options, stream_position)
+    assert mock_box_network.session.request.mock_calls == [
+        call(
+            'GET',
+            options['url'],
+            headers={'Authorization': 'Bearer {}'.format(access_token), 'BoxApi': box_api_header},
+            timeout=options['retry_timeout'],
+            params={'stream_position': stream_position},
+        ),
+    ]
+
+
+def test_metadata_endpoint_with_shared_link_causes_box_api_header_to_be_added(
+        box_client,
+        mock_box_network,
+        generic_successful_response,
+        shared_link,
+        shared_link_password,
+        box_api_header,
+        access_token,
+):
+    mock_box_network.session.request.side_effect = [
+        generic_successful_response,
+    ]
+    box_client.file('0').metadata().with_shared_link(shared_link, shared_link_password).get()
+    assert mock_box_network.session.request.mock_calls == [
+        call(
+            'GET',
+            '{0}/files/0/metadata/global/properties'.format(API.BASE_API_URL),
+            headers={'Authorization': 'Bearer {}'.format(access_token), 'BoxApi': box_api_header},
+        ),
+    ]

--- a/test/integration/test_with_shared_link.py
+++ b/test/integration/test_with_shared_link.py
@@ -19,8 +19,11 @@ def shared_link_password(request):
 
 
 @pytest.fixture
-def box_api_header(shared_link, shared_link_password):
-    return get_shared_link_header(shared_link, shared_link_password)['BoxApi']
+def box_api_headers(shared_link, shared_link_password, access_token):
+    # pylint:disable=redefined-outer-name
+    box_api_header = get_shared_link_header(shared_link, shared_link_password)['BoxApi']
+    return {'Authorization': 'Bearer {0}'.format(access_token), 'BoxApi': box_api_header}
+
 
 def test_client_with_shared_link_causes_box_api_header_to_be_added(
         box_client,
@@ -28,9 +31,9 @@ def test_client_with_shared_link_causes_box_api_header_to_be_added(
         generic_successful_response,
         shared_link,
         shared_link_password,
-        box_api_header,
-        access_token,
+        box_api_headers,
 ):
+    # pylint:disable=redefined-outer-name
     mock_box_network.session.request.side_effect = [
         generic_successful_response,
     ]
@@ -39,7 +42,7 @@ def test_client_with_shared_link_causes_box_api_header_to_be_added(
         call(
             'GET',
             '{0}/folders/0'.format(API.BASE_API_URL),
-            headers={'Authorization': 'Bearer {}'.format(access_token), 'BoxApi': box_api_header},
+            headers=box_api_headers,
             params=None,
         ),
     ]
@@ -51,9 +54,9 @@ def test_folder_object_with_shared_link_causes_box_api_header_to_be_added(
         generic_successful_response,
         shared_link,
         shared_link_password,
-        box_api_header,
-        access_token,
+        box_api_headers,
 ):
+    # pylint:disable=redefined-outer-name
     mock_box_network.session.request.side_effect = [
         generic_successful_response,
     ]
@@ -62,7 +65,7 @@ def test_folder_object_with_shared_link_causes_box_api_header_to_be_added(
         call(
             'GET',
             '{0}/folders/0'.format(API.BASE_API_URL),
-            headers={'Authorization': 'Bearer {}'.format(access_token), 'BoxApi': box_api_header},
+            headers=box_api_headers,
             params=None,
         ),
     ]
@@ -74,9 +77,9 @@ def test_group_membership_object_with_shared_link_causes_box_api_header_to_be_ad
         generic_successful_response,
         shared_link,
         shared_link_password,
-        box_api_header,
-        access_token,
+        box_api_headers,
 ):
+    # pylint:disable=redefined-outer-name
     mock_box_network.session.request.side_effect = [
         generic_successful_response,
     ]
@@ -87,7 +90,7 @@ def test_group_membership_object_with_shared_link_causes_box_api_header_to_be_ad
         call(
             'GET',
             '{0}/group_memberships/0'.format(API.BASE_API_URL),
-            headers={'Authorization': 'Bearer {}'.format(access_token), 'BoxApi': box_api_header},
+            headers=box_api_headers,
             params=None,
         ),
     ]
@@ -99,9 +102,9 @@ def test_events_endpoint_with_shared_link_causes_box_api_header_to_be_added(
         generic_successful_response,
         shared_link,
         shared_link_password,
-        box_api_header,
-        access_token,
+        box_api_headers,
 ):
+    # pylint:disable=redefined-outer-name
     mock_box_network.session.request.side_effect = [
         generic_successful_response,
     ]
@@ -112,7 +115,7 @@ def test_events_endpoint_with_shared_link_causes_box_api_header_to_be_added(
         call(
             'GET',
             options['url'],
-            headers={'Authorization': 'Bearer {}'.format(access_token), 'BoxApi': box_api_header},
+            headers=box_api_headers,
             timeout=options['retry_timeout'],
             params={'stream_position': stream_position},
         ),
@@ -125,9 +128,9 @@ def test_metadata_endpoint_with_shared_link_causes_box_api_header_to_be_added(
         generic_successful_response,
         shared_link,
         shared_link_password,
-        box_api_header,
-        access_token,
+        box_api_headers,
 ):
+    # pylint:disable=redefined-outer-name
     mock_box_network.session.request.side_effect = [
         generic_successful_response,
     ]
@@ -136,6 +139,6 @@ def test_metadata_endpoint_with_shared_link_causes_box_api_header_to_be_added(
         call(
             'GET',
             '{0}/files/0/metadata/global/properties'.format(API.BASE_API_URL),
-            headers={'Authorization': 'Bearer {}'.format(access_token), 'BoxApi': box_api_header},
+            headers=box_api_headers,
         ),
     ]

--- a/test/unit/conftest.py
+++ b/test/unit/conftest.py
@@ -44,21 +44,6 @@ def mock_group_response(mock_group_id, make_mock_box_request):
     return mock_box_response
 
 
-@pytest.fixture(scope='module')
-def mock_object_id():
-    return '42'
-
-
-@pytest.fixture(scope='module')
-def mock_user_id():
-    return 'fake-user-100'
-
-
-@pytest.fixture(scope='module')
-def mock_group_id():
-    return 'fake-group-99'
-
-
 @pytest.fixture()
 def make_mock_box_request():
     def inner(status_code=200, response_ok=True, response=None, content=None):

--- a/test/unit/object/test_metadata.py
+++ b/test/unit/object/test_metadata.py
@@ -105,3 +105,8 @@ def test_update(
         data=json.dumps(metadata_update.ops),
         headers={b'Content-Type': b'application/json-patch+json'},
     )
+
+
+def test_start_update(test_file):
+    update = test_file.metadata().start_update()
+    assert isinstance(update, MetadataUpdate)

--- a/test/unit/object/test_search.py
+++ b/test/unit/object/test_search.py
@@ -179,3 +179,18 @@ def test_range_filter_without_gt_and_lt_will_fail_validation():
     metadata_filter = MetadataSearchFilter(template_key='mytemplate', scope='enterprise')
     with pytest.raises(ValueError):
         metadata_filter.add_range_filter(field_key='mykey')
+
+
+def test_start_search_filters(test_search):
+    filters = test_search.start_metadata_filters()
+    assert isinstance(filters, MetadataSearchFilters)
+
+
+def test_make_single_metadata_filter(test_search):
+    template_key = 'mytemplate'
+    scope = 'myscope'
+    metadata_filter = test_search.make_single_metadata_filter(template_key, scope)
+    assert isinstance(metadata_filter, MetadataSearchFilter)
+    filter_as_dict = metadata_filter.as_dict()
+    assert filter_as_dict['templateKey'] == template_key
+    assert filter_as_dict['scope'] == scope

--- a/test/unit/test_exception.py
+++ b/test/unit/test_exception.py
@@ -30,6 +30,7 @@ def test_box_api_exception():
     assert box_exception._headers == headers  # pylint:disable=protected-access
     assert box_exception.url == url
     assert box_exception.method == method
+    assert box_exception.context_info == context_info
     assert str(box_exception) == '''
 Message: {0}
 Status: {1}

--- a/test/unit/util/test_shared_link.py
+++ b/test/unit/util/test_shared_link.py
@@ -1,0 +1,23 @@
+# coding: utf-8
+
+from __future__ import unicode_literals
+import pytest
+from boxsdk.util.shared_link import get_shared_link_header
+
+
+@pytest.fixture(params=('mock_shared_link', 'https://app.box.com/s/q2i1024dvguiads6mzj2avsq9hmz43du'))
+def shared_link(request):
+    return request.param
+
+
+@pytest.fixture(params=(None, 'shared_link_password'))
+def password(request):
+    return request.param
+
+
+def test_get_shared_link_header(shared_link, password):
+    header = get_shared_link_header(shared_link, password)
+    assert 'BoxApi' in header
+    assert shared_link in header['BoxApi']
+    if password is not None:
+        assert password in header['BoxApi']

--- a/test/unit/util/test_shared_link.py
+++ b/test/unit/util/test_shared_link.py
@@ -16,6 +16,7 @@ def password(request):
 
 
 def test_get_shared_link_header(shared_link, password):
+    # pylint:disable=redefined-outer-name
     header = get_shared_link_header(shared_link, password)
     assert 'BoxApi' in header
     assert shared_link in header['BoxApi']

--- a/tox.ini
+++ b/tox.ini
@@ -43,7 +43,7 @@ commands =
 deps = -rrequirements-dev.txt
 
 [testenv:coverage]
-commands = py.test --cov boxsdk test/unit
+commands = py.test --cov boxsdk test/unit test/integration
 deps = -rrequirements-dev.txt
 
 [testenv:docs]


### PR DESCRIPTION
The Box API supports enterprise admins making requests as users via the As-User header.
It also supports gaining access to items via a shared link via the BoxApi: shared_link= header.

This commit adds an `as_user` and `with_shared_link` method to the SDK client, session, and endpoint objects
to support a fluent interface for adding the appropriate headers to requests.

For example, to get user with id 1234's root folder info:
    client.as_user(User('1234')).folder('0').get()