### PR TITLE
Content bytes option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 # Backup files
 *.~
-kory_test.py
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 # Backup files
 *.~
-
+kory_test.py
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/boxsdk/object/file.py
+++ b/boxsdk/object/file.py
@@ -44,17 +44,24 @@ class File(Item):
         """
         return self._get_accelerator_upload_url(file_id=self._object_id)
 
-    def content(self):
+    def content(self, bytes=[]):
         """
         Get the content of a file on Box.
 
+        :peram bytes:
+            A list of two ints. These are the range value in bytes.
+        :type bytes:
+            `[int, int]`
         :returns:
             File content as bytes.
         :rtype:
             `bytes`
         """
+        headers = None
+        if bytes:
+            headers = {'Range': 'bytes=%d-%d' % (bytes[0], bytes[1])}
         url = self.get_url('content')
-        box_response = self._session.get(url, expect_json_response=False)
+        box_response = self._session.get(url, expect_json_response=False, headers=headers)
         return box_response.content
 
     def download_to(self, writeable_stream):

--- a/boxsdk/object/file.py
+++ b/boxsdk/object/file.py
@@ -44,7 +44,7 @@ class File(Item):
         """
         return self._get_accelerator_upload_url(file_id=self._object_id)
 
-    def content(self, bytes=[]):
+    def content(self, bytes=None):
         """
         Get the content of a file on Box.
 
@@ -64,7 +64,7 @@ class File(Item):
         box_response = self._session.get(url, expect_json_response=False, headers=headers)
         return box_response.content
 
-    def download_to(self, writeable_stream):
+    def download_to(self, writeable_stream, bytes=None):
         """
         Download the file; write it to the given stream.
 
@@ -73,8 +73,11 @@ class File(Item):
         :type writeable_stream:
             `file`
         """
+        headers = None
+        if bytes:
+            headers = {'Range': 'bytes=%d-%d' % (bytes[0], bytes[1])}
         url = self.get_url('content')
-        box_response = self._session.get(url, expect_json_response=False, stream=True)
+        box_response = self._session.get(url, expect_json_response=False, stream=True, headers=headers)
         for chunk in box_response.network_response.response_as_stream.stream(decode_content=True):
             writeable_stream.write(chunk)
 

--- a/boxsdk/object/file.py
+++ b/boxsdk/object/file.py
@@ -44,13 +44,13 @@ class File(Item):
         """
         return self._get_accelerator_upload_url(file_id=self._object_id)
 
-    def content(self, bytes=None):
+    def content(self, byte_range=None):
         """
         Get the content of a file on Box.
 
-        :peram bytes:
+        :param byte_range:
             A list of two ints. These are the range value in bytes.
-        :type bytes:
+        :type byte_range:
             `[int, int]`
         :returns:
             File content as bytes.
@@ -58,13 +58,13 @@ class File(Item):
             `bytes`
         """
         headers = None
-        if bytes:
-            headers = {'Range': 'bytes=%d-%d' % (bytes[0], bytes[1])}
+        if byte_range and len(byte_range) > 1:
+            headers = {'Range': 'bytes=%d-%d' % (byte_range[0], byte_range[1])}
         url = self.get_url('content')
         box_response = self._session.get(url, expect_json_response=False, headers=headers)
         return box_response.content
 
-    def download_to(self, writeable_stream, bytes=None):
+    def download_to(self, writeable_stream, byte_range=None):
         """
         Download the file; write it to the given stream.
 
@@ -72,10 +72,14 @@ class File(Item):
             A file-like object where bytes can be written into.
         :type writeable_stream:
             `file`
+        :param byte_range:
+            A list of two ints. These are the range value in bytes.
+        :type byte_range:
+            `[int, int]`
         """
         headers = None
-        if bytes:
-            headers = {'Range': 'bytes=%d-%d' % (bytes[0], bytes[1])}
+        if byte_range and len(byte_range) > 1:
+            headers = {'Range': 'bytes=%d-%d' % (byte_range[0], byte_range[1])}
         url = self.get_url('content')
         box_response = self._session.get(url, expect_json_response=False, stream=True, headers=headers)
         for chunk in box_response.network_response.response_as_stream.stream(decode_content=True):

--- a/demo/partial_file_example.py
+++ b/demo/partial_file_example.py
@@ -1,0 +1,29 @@
+# Example of the following api call
+# curl -L https://api.box.com/2.0/files/FILE_ID/content -H "Authorization: Bearer ACCESS_TOKEN" -H "Range: bytes=0-60"
+
+from boxsdk import OAuth2
+from boxsdk import Client
+
+
+oauth = OAuth2(
+    client_id='client_id',
+    client_secret='client_secret'
+)
+dev_access_code = 'Developer_token'
+oauth._access_token =dev_access_code
+
+client = Client(oauth)
+items = client.folder(folder_id='0').get_items(limit=100, offset=0)
+
+# prints items for later user
+for i in items:
+    print i.id
+
+def range_test(id):
+    bytes = [0,60]
+    k = client.file(file_id=id).content(bytes=bytes)
+    print k
+
+
+if __name__ =='__main__':
+    range_test('FILE_ID')


### PR DESCRIPTION
Added the option to include bytes when requesting the contents of a file. This is a feature that is available in API calls, but not originally in the boxsdk for python.

Example:
```python
bytes = [0,60]
client.file(file_id=id).content(bytes=bytes)
```

CLA signed