### PR TITLE
Include count of items from Folder.get_items().

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -113,7 +113,7 @@ Get items in a folder
 
 .. code-block:: python
 
-    items = client.folder(folder_id='0').get_items(limit=100, offset=0)
+    total_count, items = client.folder(folder_id='0').get_items(limit=100, offset=0)
 
 Create subfolder
 ~~~~~~~~~~~~~~~~

--- a/demo/example.py
+++ b/demo/example.py
@@ -18,8 +18,8 @@ def run_folder_examples(client):
     root_folder = client.folder(folder_id='0').get()
     print('The root folder is owned by: {0}'.format(root_folder.owned_by['login']))
 
-    items = root_folder.get_items(limit=100, offset=0)
-    print('This is the first 100 items in the root folder:')
+    total_count, items = root_folder.get_items(limit=100, offset=0)
+    print('The root folder has {} items. Here are the first 100 items:'.format(total_count))
     for item in items:
         print("   " + item.name)
 
@@ -137,11 +137,11 @@ def copy_item(client):
         subfolder1 = root_folder.create_subfolder('copy_sub')
         try:
             a_file.copy(subfolder1)
-            print(subfolder1.get_items(limit=10, offset=0))
+            print(subfolder1.get_items(limit=10, offset=0).items)
             subfolder2 = root_folder.create_subfolder('copy_sub2')
             try:
                 subfolder1.copy(subfolder2)
-                print(subfolder2.get_items(limit=10, offset=0))
+                print(subfolder2.get_items(limit=10, offset=0).items)
             finally:
                 subfolder2.delete()
         finally:
@@ -158,11 +158,11 @@ def move_item(client):
         subfolder1 = root_folder.create_subfolder('move_sub')
         try:
             a_file.move(subfolder1)
-            print(subfolder1.get_items(limit=10, offset=0))
+            print(subfolder1.get_items(limit=10, offset=0).items)
             subfolder2 = root_folder.create_subfolder('move_sub2')
             try:
                 subfolder1.move(subfolder2)
-                print(subfolder2.get_items(limit=10, offset=0))
+                print(subfolder2.get_items(limit=10, offset=0).items)
             finally:
                 subfolder2.delete()
         finally:

--- a/test/functional/test_delete.py
+++ b/test/functional/test_delete.py
@@ -11,13 +11,13 @@ def test_upload_then_delete(box_client, test_file_path, test_file_content, file_
     with patch('boxsdk.object.folder.open', mock_open(read_data=test_file_content), create=True):
         file_object = box_client.folder('0').upload(test_file_path, file_name)
     assert file_object.delete()
-    assert len(box_client.folder('0').get_items(1)) == 0
+    assert len(box_client.folder('0').get_items(1).items) == 0
 
 
 def test_create_folder_then_update_info(box_client, folder_name):
     folder = box_client.folder('0').create_subfolder(folder_name)
     assert folder.delete()
-    assert len(box_client.folder('0').get_items(1)) == 0
+    assert len(box_client.folder('0').get_items(1).items) == 0
 
 
 @pytest.mark.parametrize('constructor', [Client.file, Client.folder])

--- a/test/functional/test_file_upload_update_download.py
+++ b/test/functional/test_file_upload_update_download.py
@@ -16,7 +16,7 @@ def test_upload_then_update(box_client, test_file_path, test_file_content, updat
     expected_file_content = test_file_content.encode('utf-8') if isinstance(test_file_content, six.text_type)\
         else test_file_content
     assert file_content == expected_file_content
-    folder_items = box_client.folder('0').get_items(100)
+    folder_items = box_client.folder('0').get_items(100).items
     assert len(folder_items) == 1
     assert folder_items[0].object_id == file_object.object_id
     assert folder_items[0].name == file_object.name
@@ -28,7 +28,7 @@ def test_upload_then_update(box_client, test_file_path, test_file_content, updat
     assert file_object_with_info.name == file_name
     file_content = updated_file_object.content()
     assert file_content == expected_file_content
-    folder_items = box_client.folder('0').get_items(100)
+    folder_items = box_client.folder('0').get_items(100).items
     assert len(folder_items) == 1
     assert folder_items[0].object_id == file_object.object_id
     assert folder_items[0].name == file_object.name

--- a/test/functional/test_item_info.py
+++ b/test/functional/test_item_info.py
@@ -57,8 +57,8 @@ def _test_create_then_move(box_client, item):
     item = item.get()
     assert item.name == item_name
     assert item.parent['id'] == move_target.object_id
-    assert len(box_client.folder('0').get_items(10)) == 1
-    assert len(move_target.get_items(10)) == 1
+    assert len(box_client.folder('0').get_items(10).items) == 1
+    assert len(move_target.get_items(10).items) == 1
 
 
 def test_create_folder_then_copy(box_client, created_subfolder):
@@ -80,8 +80,8 @@ def _test_create_then_copy(box_client, item):
     assert item.id != copied_item.id
     assert item.name == copied_item.name
     assert copied_item.parent['id'] == copy_target.object_id
-    assert len(box_client.folder('0').get_items(10)) == 2
-    assert len(copy_target.get_items(10)) == 1
+    assert len(box_client.folder('0').get_items(10).items) == 2
+    assert len(copy_target.get_items(10).items) == 1
 
 
 @pytest.mark.parametrize('constructor', [Client.file, Client.folder])

--- a/test/unit/object/test_folder.py
+++ b/test/unit/object/test_folder.py
@@ -57,7 +57,10 @@ def mock_items_response(mock_items):
         mock_box_response = Mock(BoxResponse)
         mock_network_response = Mock(DefaultNetworkResponse)
         mock_box_response.network_response = mock_network_response
-        mock_box_response.json.return_value = mock_json = {'entries': items_json[offset:limit + offset]}
+        mock_box_response.json.return_value = mock_json = {
+            'total_count': len(items),
+            'entries': items_json[offset:limit + offset],
+        }
         mock_box_response.content = json.dumps(mock_json).encode()
         mock_box_response.status_code = 200
         mock_box_response.ok = True
@@ -130,11 +133,12 @@ def test_get_items(test_folder, mock_box_session, mock_items_response, limit, of
     # pylint:disable=redefined-outer-name
     expected_url = test_folder.get_url('items')
     mock_box_session.get.return_value, expected_items = mock_items_response(limit, offset)
-    items = test_folder.get_items(limit, offset, fields)
+    total_count, items = test_folder.get_items(limit, offset, fields)
     expected_params = {'limit': limit, 'offset': offset}
     if fields:
         expected_params['fields'] = ','.join(fields)
     mock_box_session.get.assert_called_once_with(expected_url, params=expected_params)
+    assert total_count == 3
     assert items == expected_items
     assert all([i.id == e.object_id for i, e in zip(items, expected_items)])
 


### PR DESCRIPTION
When paginating a folder's items, the number of items in the folder
could have changed between successive calls. Including the count of
items helps the caller adjust the pagination as required.