### PR TITLE
Add support for py35, pypy with cryptography>=1.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,8 @@ var/
 *.egg
 MANIFEST
 .eggs/
+.pyenv/
+.venv/
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,39 @@
 sudo: false
 language: python
-python: 2.7
-env:
-  - TOX_ENV=py26
-  - TOX_ENV=py27
-  - TOX_ENV=py33
-  - TOX_ENV=py34
-  - TOX_ENV=pypy
-  - TOX_ENV=pep8
-  - TOX_ENV=pylint
-  - TOX_ENV=coverage
+
+cache:
+  directories:
+    - $HOME/.cache/pip
+
+before_cache:
+  - rm -r -f $HOME/.cache/pip/log
+
+matrix:
+  include:
+    - python: 2.6
+      env: TOX_ENV=py26
+    - python: 2.7
+      env: TOX_ENV=py27
+    - python: 3.3
+      env: TOX_ENV=py33
+    - python: 3.4
+      env: TOX_ENV=py34
+    - python: 3.5
+      env: TOX_ENV=py35
+    - python: pypy
+      env: TOX_ENV=pypy
+    - python: 2.7
+      env: TOX_ENV=pep8
+    - python: 2.7
+      env: TOX_ENV=pylint
+    - python: 2.7
+      env: TOX_ENV=coverage
+
 # commands to install dependencies
 install:
-  - pip install tox --use-mirrors
+  - ./.travis/install.sh
 # commands to run
 script:
-  - tox -e $TOX_ENV
+  - ./.travis/run.sh
 after_success:
   - if [ "-x$TOX_ENV" = "xcoverage" ]; then coveralls; fi

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+
+# Originally from
+# <https://github.com/pyca/cryptography/blob/d93aa99636b06d5d403130425098b2f0cc1b516e/.travis/install.sh>.
+
+set -e
+set -x
+set -o pipefail
+
+git clean -f -d -X
+rm -r -f $PWD/.pyenv  # Apparently `git-clean` won't remove other repositories.
+
+if [[ "$(uname -s)" == 'Darwin' ]]; then
+    brew update || brew update
+    brew install pyenv
+    brew outdated pyenv || brew upgrade pyenv
+
+    if which -s pyenv; then
+        rm -r -f $HOME/.pyenv
+        eval "$(pyenv init -)"
+    fi
+
+    case "${TOX_ENV}" in
+        py26)
+            curl -O https://bootstrap.pypa.io/get-pip.py
+            python get-pip.py --user
+            ;;
+        py27)
+            curl -O https://bootstrap.pypa.io/get-pip.py
+            python get-pip.py --user
+            ;;
+        py33)
+            pyenv install 3.3.6
+            pyenv global 3.3.6
+            ;;
+        py34)
+            pyenv install 3.4.2
+            pyenv global 3.4.2
+            ;;
+        py35)
+            pyenv install 3.5.0
+            pyenv global 3.5.0
+            ;;
+        pypy)
+            pyenv install pypy-2.6.0
+            pyenv global pypy-2.6.0
+            ;;
+    esac
+    pyenv rehash
+    python -m pip install -U --user virtualenv
+else
+    # temporary pyenv installation to get pypy-2.6 before container infra upgrade
+    if [[ "${TOX_ENV}" == "pypy" ]]; then
+        git clone https://github.com/yyuu/pyenv.git $PWD/.pyenv
+        export PYENV_ROOT="$PWD/.pyenv"
+        export PATH="$PYENV_ROOT/bin:$PATH"
+        eval "$(pyenv init -)"
+        pyenv install pypy-2.6.0
+        pyenv global pypy-2.6.0
+    fi
+    pip install -U virtualenv
+fi
+
+python -m virtualenv $PWD/.venv
+source $PWD/.venv/bin/activate
+pip install -U tox

--- a/.travis/run.sh
+++ b/.travis/run.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# Originally from
+# <https://github.com/pyca/cryptography/blob/d93aa99636b06d5d403130425098b2f0cc1b516e/.travis/install.sh>.
+
+set -e
+set -x
+set -o pipefail
+
+if [[ "$(uname -s)" == "Darwin" ]]; then
+    eval "$(pyenv init -)"
+else
+    if [[ "${TOX_ENV}" == "pypy" ]]; then
+        export PYENV_ROOT="$PWD/.pyenv"
+        export PATH="$PYENV_ROOT/bin:$PATH"
+        eval "$(pyenv init -)"
+        pyenv global pypy-2.6.0
+    fi
+fi
+source $PWD/.venv/bin/activate
+tox -e $TOX_ENV -- $TOX_FLAGS

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,6 +6,10 @@ Release History
 Upcoming
 ++++++++
 
+- CPython 3.5 support.
+- Support for cryptography>=1.0 on PyPy 2.6.
+- Travis CI testing for CPython 3.5 and PyPy 2.6.0.
+
 1.2.1 (2015-07-22)
 ++++++++++++++++++
 

--- a/README.rst
+++ b/README.rst
@@ -311,8 +311,8 @@ Run all tests using -
 
 The tox tests include code style checks via pep8 and pylint.
 
-The tox tests are configured to run on Python 2.6, 2.7, 3.3, 3.4, and
-PyPy.
+The tox tests are configured to run on Python 2.6, 2.7, 3.3, 3.4, 3.5, and
+PyPy 2.6.
 
 
 Support

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 cryptography>=0.9.2
-enum34>=1.0.4
-ordereddict>=1.1
 pyjwt>=1.3.0
 requests>=2.4.3
 six >= 1.4.0
+.

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ CLASSIFIERS = [
     'Programming Language :: Python :: 2.7',
     'Programming Language :: Python :: 3.3',
     'Programming Language :: Python :: 3.4',
+    'Programming Language :: Python :: 3.5',
     'Programming Language :: Python :: Implementation :: CPython',
     'Programming Language :: Python :: Implementation :: PyPy',
     'Operating System :: OS Independent',
@@ -52,11 +53,7 @@ class PyTest(TestCommand):
 def main():
     base_dir = dirname(__file__)
     install_requires = ['requests>=2.4.3', 'six>=1.4.0']
-    jwt_requires = ['pyjwt>=1.3.0']
-    if platform.python_implementation() == 'PyPy':
-        jwt_requires.append('cryptography>=0.9.2, <1.0')
-    else:
-        jwt_requires.append('cryptography>=0.9.2')
+    jwt_requires = ['pyjwt>=1.3.0', 'cryptography>=0.9.2']
     if version_info < (3, 4):
         install_requires.append('enum34>=1.0.4')
     elif version_info < (2, 7):

--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,7 @@ envlist =
   py27,
   py33,
   py34,
+  py35,
   pypy,
   pep8,
   pylint,
@@ -20,12 +21,6 @@ envlist =
 commands =
   py.test test/ {posargs}
 deps = -rrequirements-dev.txt
-
-[testenv:pypy]
-deps = -rrequirements-dev.txt
-commands =
-  pip install cryptography==0.9.3 --upgrade
-  py.test test/ {posargs}
 
 [testenv:rst]
 deps =


### PR DESCRIPTION
Add support and testing for:
- CPython 3.5
- cryptography>=1.0 on PyPy 2.6.0.

PyPy 2.6 isn't available by default on Travis CI. Only PyPy 2.5 is, but that is incompatible with cryptography>=1.0 [1].

Borrow some of the Travis CI setup from the PyCA's cryptography project [2], which installs pyenv [3] in order to bootstrap an installation for PyPy 2.6.

[1] <https://github.com/travis-ci/travis-ci/issues/4756>
[2] <https://github.com/pyca/cryptography/tree/master/.travis>
[3] <https://github.com/yyuu/pyenv>