### PR TITLE
Rename uses of enterprise_token to enterprise_id

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -248,7 +248,7 @@ instead use an instance of `JWTAuth`.
     auth = JWTAuth(
         client_id='YOUR_CLIENT_ID',
         client_secret='YOUR_CLIENT_SECRET',
-        enterprise_token='YOUR_ENTERPRISE_TOKEN',
+        enterprise_id='YOUR_ENTERPRISE_ID',
         rsa_private_key_file_sys_path='CERT.PEM',
         store_tokens=your_store_tokens_callback_method,
     )
@@ -272,7 +272,7 @@ These users can then be authenticated:
     ned_auth = JWTAuth(
        client_id='YOUR_CLIENT_ID',
        client_secret='YOUR_CLIENT_SECRET',
-       enterprise_token='YOUR_ENTERPRISE_TOKEN',
+       enterprise_id='YOUR_ENTERPRISE_ID',
        rsa_private_key_file_sys_path='CERT.PEM',
        store_tokens=your_store_tokens_callback_method,
    )

--- a/boxsdk/auth/jwt_auth.py
+++ b/boxsdk/auth/jwt_auth.py
@@ -93,7 +93,7 @@ class JWTAuth(OAuth2):
                 password=rsa_private_key_passphrase,
                 backend=default_backend(),
             )
-        self._enterprise_token = enterprise_id
+        self._enterprise_id = enterprise_id
         self._jwt_algorithm = jwt_algorithm
         self._user_id = None
 
@@ -170,7 +170,7 @@ class JWTAuth(OAuth2):
         :rtype:
             `unicode`
         """
-        return self._auth_with_jwt(self._enterprise_token, 'enterprise')
+        return self._auth_with_jwt(self._enterprise_id, 'enterprise')
 
     def _refresh(self, access_token):
         """

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,7 +4,14 @@ jsonpatch
 mock<=1.0.1
 pep8
 pylint
-pytest
+
+# Temporary version exclusion of the 2.8 release line.
+# <https://github.com/pytest-dev/pytest/issues/1085> breaks pytest on Python 2, only in 2.8.1. Fixed in upcoming 2.8.2.
+# <https://github.com/pytest-dev/pytest/issues/1035> breaks pytest on Python 2.6, on all currently existing 2.8.*
+# releases. Has not yet been fixed in the master branch, so there isn't a guarantee that it will work in the upcoming
+# 2.8.2 release.
+pytest<2.8
+
 pytest-cov
 pytest-xdist
 sphinx

--- a/test/unit/auth/test_jwt_auth.py
+++ b/test/unit/auth/test_jwt_auth.py
@@ -48,7 +48,7 @@ def jwt_auth_init_mocks(
         successful_token_response,
         jwt_algorithm,
         rsa_passphrase,
-        enterprise_token=None,
+        enterprise_id=None,
 ):
     # pylint:disable=redefined-outer-name
     fake_client_id = 'fake_client_id'
@@ -70,7 +70,7 @@ def jwt_auth_init_mocks(
             oauth = JWTAuth(
                 client_id=fake_client_id,
                 client_secret=fake_client_secret,
-                enterprise_id=enterprise_token,
+                enterprise_id=enterprise_id,
                 rsa_private_key_file_sys_path=sentinel.rsa_path,
                 rsa_private_key_passphrase=rsa_passphrase,
                 network_layer=mock_network_layer,
@@ -153,15 +153,15 @@ def test_authenticate_instance_sends_post_request_with_correct_params(
         rsa_passphrase,
 ):
     # pylint:disable=redefined-outer-name
-    enterprise_token = 'fake_enterprise_token'
+    enterprise_id = 'fake_enterprise_id'
     with jwt_auth_init_mocks(
         mock_network_layer,
         successful_token_response,
         jwt_algorithm,
         rsa_passphrase,
-        enterprise_token,
+        enterprise_id,
     ) as params:
-        with jwt_auth_auth_mocks(jti_length, jwt_algorithm, enterprise_token, 'enterprise', *params) as oauth:
+        with jwt_auth_auth_mocks(jti_length, jwt_algorithm, enterprise_id, 'enterprise', *params) as oauth:
             oauth.authenticate_instance()
 
 
@@ -188,13 +188,13 @@ def test_refresh_instance_sends_post_request_with_correct_params(
         rsa_passphrase,
 ):
     # pylint:disable=redefined-outer-name
-    enterprise_token = 'fake_enterprise_token'
+    enterprise_id = 'fake_enterprise_id'
     with jwt_auth_init_mocks(
         mock_network_layer,
         successful_token_response,
         jwt_algorithm,
         rsa_passphrase,
-        enterprise_token,
+        enterprise_id,
     ) as params:
-        with jwt_auth_auth_mocks(jti_length, jwt_algorithm, enterprise_token, 'enterprise', *params) as oauth:
+        with jwt_auth_auth_mocks(jti_length, jwt_algorithm, enterprise_id, 'enterprise', *params) as oauth:
             oauth.refresh(None)


### PR DESCRIPTION
This parameter is referred to as `enterprise_id` in the Box Developer documentation. Also, the noun "token" is already used to refer to the data returned at the end of the auth process. So rename this to reduce confusion.

This is a backwards compatible change, because the method parameter name was already correct. This is only a change to private attributes, test code, and documentation.

Also add a temporary pip version exclusion on the latest version of pytest, which is broken on Python 2. See https://github.com/pytest-dev/pytest/issues/1085 and https://github.com/pytest-dev/pytest/issues/1035.