### PR TITLE
Add requests-toolbelt to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ class PyTest(TestCommand):
 
 def main():
     base_dir = dirname(__file__)
-    install_requires = ['requests>=2.4.3', 'six>=1.4.0']
+    install_requires = ['requests>=2.4.3', 'six>=1.4.0', 'requests-toolbelt>=0.4.0']
     redis_requires = ['redis>=2.10.3']
     jwt_requires = ['pyjwt>=1.3.0', 'cryptography>=0.9.2']
     if version_info < (3, 4):


### PR DESCRIPTION
requests-toolbelt was added to the requirements.txt but not setup.py.

Is there a reason that both are needed or could it be consolidated to just using requirements.txt.