### PR TITLE
Replace `basestring` with `six.string_types`

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,6 +6,16 @@ Release History
 Upcoming
 ++++++++
 
+1.3.2
+++++++++++++++++++
+
+- Fix ``boxsdk.util.log.setup_logging()`` on Python 3.
+
+1.3.1 (2015-11-06)
+++++++++++++++++++
+
+- Add requests-toolbelt to setup.py (it was accidentally missing from 1.3.0).
+
 1.3.0 (2015-11-05)
 ++++++++++++++++++
 
@@ -32,11 +42,11 @@ Upcoming
 ++++++++++++++++++
 
 - Added support for Box Developer Edition. This includes JWT auth (auth as enterprise or as app user),
-  and `create_user` functionality.
+  and ``create_user`` functionality.
 - Added support for setting shared link expiration dates.
 - Added support for setting shared link permissions.
 - Added support for 'As-User' requests. See https://box-content.readme.io/#as-user-1
-- Improved support for accessing shared items. Items returned from the `client.get_shared_item` method will
+- Improved support for accessing shared items. Items returned from the ``client.get_shared_item`` method will
   remember the shared link (and the optionally provided shared link password) so methods called on the returned
   items will be properly authorized.
 
@@ -71,7 +81,7 @@ Upcoming
 1.1.3 (2015-03-26)
 ++++++++++++++++++
 
-- Added support for the /shared_items endpoint. `client.get_shared_item` can be used to get information about
+- Added support for the /shared_items endpoint. ``client.get_shared_item`` can be used to get information about
   a shared link. See https://developers.box.com/docs/#shared-items
 
 1.1.2 (2015-03-20)

--- a/boxsdk/util/log.py
+++ b/boxsdk/util/log.py
@@ -4,6 +4,8 @@ from __future__ import unicode_literals
 import logging
 import sys
 
+from six import string_types
+
 
 def setup_logging(stream_or_file=None, debug=False, name=None):
     """
@@ -28,7 +30,7 @@ def setup_logging(stream_or_file=None, debug=False, name=None):
         :class:`Logger`
     """
     logger = logging.getLogger(name)
-    if isinstance(stream_or_file, basestring):
+    if isinstance(stream_or_file, string_types):
         handler = logging.FileHandler(stream_or_file, mode='w')
     else:
         handler = logging.StreamHandler(stream_or_file or sys.stdout)

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ def main():
         install_requires.append('ordereddict>=1.1')
     setup(
         name='boxsdk',
-        version='1.3.1',
+        version='1.3.2',
         description='Official Box Python SDK',
         long_description=open(join(base_dir, 'README.rst')).read(),
         author='Box',

--- a/test/unit/network/test_logging_network.py
+++ b/test/unit/network/test_logging_network.py
@@ -16,6 +16,14 @@ def test_logging_network_calls_setup_logging_if_logger_is_none():
         assert network.logger is setup_logging.return_value
 
 
+def test_logging_network_can_be_initialized_if_logger_is_none():
+    with patch('logging.getLogger') as get_logger:
+        get_logger.return_value = Mock(Logger)
+        network = LoggingNetwork()
+        assert network.logger is get_logger.return_value
+        get_logger.assert_called_once_with(LoggingNetwork.LOGGER_NAME)
+
+
 def test_logging_network_does_not_call_setup_logging_if_logger_is_not_none():
     logger = Mock(Logger)
     with patch.object(logging_network, 'setup_logging') as setup_logging:

--- a/test/unit/util/test_log.py
+++ b/test/unit/util/test_log.py
@@ -1,0 +1,59 @@
+# coding: utf-8
+
+from __future__ import absolute_import, unicode_literals
+
+import io
+import logging
+
+from mock import mock_open, patch, Mock
+import pytest
+from six import string_types
+
+import boxsdk.util.log
+
+
+_MOCK_FILEPATH = '/home/user/boxsdk.log'
+_MOCK_LOG_NAME = 'boxsdk'
+
+
+@pytest.fixture(params=[io.StringIO(), _MOCK_FILEPATH])
+def stream_or_file(request):
+    return request.param
+
+
+@pytest.fixture(params=[False, True])
+def debug(request):
+    return request.param
+
+
+@pytest.fixture
+def expected_log_level(debug):
+    return logging.DEBUG if debug else logging.INFO
+
+
+@pytest.fixture(params=[_MOCK_LOG_NAME, None])
+def name(request):
+    return request.param
+
+
+@pytest.fixture
+def mock_logger():
+    return Mock(logging.Logger)
+
+
+def test_setup_logging(stream_or_file, debug, expected_log_level, name, mock_logger):
+    mock_file_open = mock_open()
+
+    with patch('logging.getLogger') as get_logger:
+        with patch('logging.open', mock_file_open, create=True):
+            get_logger.return_value = mock_logger
+            assert boxsdk.util.log.setup_logging(stream_or_file, debug=debug, name=name) == mock_logger
+            get_logger.assert_called_once_with(name)
+
+    assert mock_logger.addHandler.call_count == 1
+    assert isinstance(mock_logger.addHandler.call_args[0][0], logging.Handler)
+    mock_logger.setLevel.assert_called_once_with(expected_log_level)
+
+    if isinstance(stream_or_file, string_types):
+        assert mock_file_open.call_count == 1
+        assert mock_file_open.call_args[0][:2] == (stream_or_file, 'w')   # Python 3 passes additional args.

--- a/tox.ini
+++ b/tox.ini
@@ -41,7 +41,8 @@ deps =
 [testenv:pylint]
 commands =
   pylint --rcfile=.pylintrc boxsdk
-  pylint --rcfile=.pylintrc test
+  # pylint:disable W0621(redefined-outer-name) - Using py.test fixtures always breaks this rule.
+  pylint --rcfile=.pylintrc test -d W0621
 deps = -rrequirements-dev.txt
 
 [testenv:coverage]


### PR DESCRIPTION
On Python 3, calling `setup_logging()` in `boxsdk.util.log`
would always raise

    NameError: name 'basestring' is not defined

On Python 3, this prevented `LoggingNetwork` from being
initialized without passing an existing `Logger`.

Replace this usage of `basestring` with the equivalent
`six.string_types`.

Add unit test coverage of `boxsdk.util.log`.

Bump version to 1.3.2.