### PR TITLE
Add stream_type param for events long polling

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -18,6 +18,11 @@ box-python-sdk
     :target: https://pypi.python.org/pypi/boxsdk
 
 
+
+.. contents:: :depth: 1
+
+
+
 Installing
 ----------
 
@@ -224,9 +229,9 @@ Metadata
 As-User
 ~~~~~~~
 
-The `Client` class and all Box objects also have an `as_user` method.
+The ``Client`` class and all Box objects also have an ``as_user`` method.
 
-`as-user` returns a copy of the object on which it was called that will make Box API requests
+``as-user`` returns a copy of the object on which it was called that will make Box API requests
 as though the specified user was making it.
 
 See https://box-content.readme.io/#as-user-1 for more information about how this works via the Box API.
@@ -254,8 +259,8 @@ Developer Edition support requires some extra dependencies. To get them, simply
 
     pip install boxsdk[jwt]
 
-Instead of instantiating your `Client` with an instance of `OAuth2`,
-instead use an instance of `JWTAuth`.
+Instead of instantiating your ``Client`` with an instance of ``OAuth2``,
+instead use an instance of ``JWTAuth``.
 
 .. code-block:: python
 
@@ -295,7 +300,7 @@ These users can then be authenticated:
    ned_auth.authenticate_app_user(ned_stark_user)
    ned_client = Client(ned_auth)
 
-Requests made with `ned_client` (or objects returned from `ned_client`'s methods)
+Requests made with ``ned_client`` (or objects returned from ``ned_client``'s methods)
 will be performed on behalf of the newly created app user.
 
 Other Auth Options
@@ -303,18 +308,18 @@ Other Auth Options
 
 For advanced uses of the SDK, two additional auth classes are provided:
 
-- `CooperativelyManagedOAuth2`: Allows multiple auth instances to share tokens.
-- `RemoteOAuth2`: Allows use of the SDK on clients without access to your application's client secret. Instead, you
-  provide a `retrieve_access_token` callback. That callback should perform the token refresh, perhaps on your server
+- ``CooperativelyManagedOAuth2``: Allows multiple auth instances to share tokens.
+- ``RemoteOAuth2``: Allows use of the SDK on clients without access to your application's client secret. Instead, you
+  provide a ``retrieve_access_token`` callback. That callback should perform the token refresh, perhaps on your server
   that does have access to the client secret.
-- `RedisManagedOAuth2`: Stores access and refresh tokens in Redis. This allows multiple processes (possibly spanning
+- ``RedisManagedOAuth2``: Stores access and refresh tokens in Redis. This allows multiple processes (possibly spanning
   multiple machines) to share access tokens while synchronizing token refresh. This could be useful for a multiprocess
   web server, for example.
 
 Other Network Options
 ---------------------
 
-For more insight into the network calls the SDK is making, you can use the `LoggingNetwork` class. This class logs
+For more insight into the network calls the SDK is making, you can use the ``LoggingNetwork`` class. This class logs
 information about network requests and responses made to the Box API.
 
 .. code-block:: python

--- a/boxsdk/object/events.py
+++ b/boxsdk/object/events.py
@@ -1,10 +1,53 @@
 # coding: utf-8
 
 from __future__ import unicode_literals
+
 from requests.exceptions import Timeout
+from six import with_metaclass
 
 from boxsdk.object.base_endpoint import BaseEndpoint
+from boxsdk.util.enum import ExtendableEnumMeta
 from boxsdk.util.lru_cache import LRUCache
+from boxsdk.util.text_enum import TextEnum
+
+
+# pylint:disable=too-many-ancestors
+class EventsStreamType(with_metaclass(ExtendableEnumMeta, TextEnum)):
+    """An enum of all possible values of the `stream_type` parameter for user events.
+
+    The value of the `stream_type` parameter determines the type of events
+    returned by the endpoint.
+
+    <https://box-content.readme.io/reference#events>
+    """
+
+
+class UserEventsStreamType(EventsStreamType):
+    """An enum of all possible values of the `stream_type` parameter for user events.
+
+    - ALL: Returns all user events.
+    - CHANGES: Returns tree changes.
+    - SYNC: Returns tree changes only for sync folders.
+
+    <https://box-content.readme.io/reference#standard-user-events>
+    """
+    ALL = 'all'
+    CHANGES = 'changes'
+    SYNC = 'sync'
+
+
+class EnterpriseEventsStreamType(EventsStreamType):
+    """An enum of all possible values of the `stream_type` parameter for enterprise events.
+
+    - ADMIN_LOGS: Retrieves up to a year's events for all users in the enterprise.
+
+    NOTE: Requires Admin: These stream types will only work with an auth token
+    from an enterprise admin account.
+
+    <https://box-content.readme.io/reference#enterprise-events>
+    """
+    ADMIN_LOGS = 'admin_logs'
+# pylint:enable=too-many-ancestors
 
 
 class Events(BaseEndpoint):
@@ -14,7 +57,7 @@ class Events(BaseEndpoint):
         """Base class override."""
         return super(Events, self).get_url('events', *args)
 
-    def get_events(self, limit=100, stream_position=0, stream_type='all'):
+    def get_events(self, limit=100, stream_position=0, stream_type=UserEventsStreamType.ALL):
         """
         Get Box events from a given stream position for a given stream type.
 
@@ -25,12 +68,16 @@ class Events(BaseEndpoint):
         :param stream_position:
             The location in the stream from which to start getting events. 0 is the beginning of time. 'now' will
             return no events and just current stream position.
+
+            NOTE: Currently, 'now' is only valid for user events stream types. The request will fail if an
+            enterprise events stream type is passed.
         :type stream_position:
             `unicode`
         :param stream_type:
-            Which type of events to return. Can be 'all', 'tree', or 'sync'.
+            (optional) Which type of events to return.
+            Defaults to `UserEventsStreamType.ALL`.
         :type stream_type:
-            `unicode`
+            :enum:`EventsStreamType`
         :returns:
             JSON response from the Box /events endpoint. Contains the next stream position to use for the next call,
             along with some number of events.
@@ -46,26 +93,38 @@ class Events(BaseEndpoint):
         box_response = self._session.get(url, params=params)
         return box_response.json()
 
-    def get_latest_stream_position(self):
+    def get_latest_stream_position(self, stream_type=UserEventsStreamType.ALL):
         """
         Get the latest stream position. The return value can be used with :meth:`get_events` or
         :meth:`generate_events_with_long_polling`.
 
+        :param stream_type:
+            (optional) Which events stream to query.
+            Defaults to `UserEventsStreamType.ALL`.
+
+            NOTE: Currently, the Box API requires this to be one of the user
+            events stream types. The request will fail if an enterprise events
+            stream type is passed.
+        :type stream_type:
+            :enum:`UserEventsStreamType`
         :returns:
             The latest stream position.
         :rtype:
             `unicode`
         """
-        url = self.get_url()
-        params = {
-            'stream_position': 'now',
-        }
-        return self._session.get(url, params=params).json()['next_stream_position']
+        return self.get_events(limit=0, stream_position='now', stream_type=stream_type)['next_stream_position']
 
-    def _get_all_events_since(self, stream_position):
+    def _get_all_events_since(self, stream_position, stream_type=UserEventsStreamType.ALL):
+        """
+        :param stream_type:
+            (optional) Which type of events to return.
+            Defaults to `UserEventsStreamType.ALL`.
+        :type stream_type:
+            :enum:`EventsStreamType`
+        """
         next_stream_position = stream_position
         while True:
-            events = self.get_events(stream_position=next_stream_position, limit=100)
+            events = self.get_events(stream_position=next_stream_position, limit=100, stream_type=stream_type)
             next_stream_position = events['next_stream_position']
             events = events['entries']
             if not events:
@@ -102,7 +161,7 @@ class Events(BaseEndpoint):
         )
         return long_poll_response
 
-    def generate_events_with_long_polling(self, stream_position=None):
+    def generate_events_with_long_polling(self, stream_position=None, stream_type=UserEventsStreamType.ALL):
         """
         Subscribe to events from the given stream position.
 
@@ -111,15 +170,24 @@ class Events(BaseEndpoint):
             return no events and just current stream position.
         :type stream_position:
             `unicode`
+        :param stream_type:
+            (optional) Which type of events to return.
+            Defaults to `UserEventsStreamType.ALL`.
+
+            NOTE: Currently, the Box API requires this to be one of the user
+            events stream types. The request will fail if an enterprise events
+            stream type is passed.
+        :type stream_type:
+            :enum:`UserEventsStreamType`
         :returns:
             Events corresponding to changes on Box in realtime, as they come in.
         :rtype:
             `generator` of :class:`Event`
         """
         event_ids = LRUCache()
-        stream_position = stream_position if stream_position is not None else self.get_latest_stream_position()
+        stream_position = stream_position if stream_position is not None else self.get_latest_stream_position(stream_type=stream_type)
         while True:
-            options = self.get_long_poll_options()
+            options = self.get_long_poll_options(stream_type=stream_type)
             while True:
                 try:
                     long_poll_response = self.long_poll(options, stream_position)
@@ -129,7 +197,7 @@ class Events(BaseEndpoint):
                     message = long_poll_response.json()['message']
                     if message == 'new_change':
                         next_stream_position = stream_position
-                        for event, next_stream_position in self._get_all_events_since(stream_position):
+                        for event, next_stream_position in self._get_all_events_since(stream_position, stream_type=stream_type):
                             try:
                                 event_ids.get(event['event_id'])
                             except KeyError:
@@ -142,10 +210,15 @@ class Events(BaseEndpoint):
                     else:
                         break
 
-    def get_long_poll_options(self):
+    def get_long_poll_options(self, stream_type=UserEventsStreamType.ALL):
         """
         Get the url and retry timeout for setting up a long polling connection.
 
+        :param stream_type:
+            (optional) Which type of events to return.
+            Defaults to `UserEventsStreamType.ALL`.
+        :type stream_type:
+            :enum:`EventsStreamType`
         :returns:
             A `dict` including a long poll url, retry timeout, etc.
             E.g.
@@ -160,5 +233,6 @@ class Events(BaseEndpoint):
             `dict`
         """
         url = self.get_url()
-        box_response = self._session.options(url)
+        params = {'stream_type': stream_type}
+        box_response = self._session.options(url, params=params)
         return box_response.json()['entries'][0]

--- a/boxsdk/util/enum.py
+++ b/boxsdk/util/enum.py
@@ -1,0 +1,147 @@
+# coding: utf-8
+
+from __future__ import absolute_import, unicode_literals
+
+from itertools import chain
+import sys
+
+from enum import EnumMeta
+from six import reraise
+from six.moves import map   # pylint:disable=redefined-builtin
+
+from .ordered_dict import OrderedDict
+
+
+__all__ = list(map(str, ['ExtendableEnumMeta']))
+
+
+class ExtendableEnumMeta(EnumMeta):
+    """A metaclass for enum hierarchies.
+
+    This allows you to define hierarchies such as this:
+
+        class EnumBase(six.with_metaclass(ExtendableEnumMeta, Enum)): pass
+
+        class Enum1(EnumBase):
+            A = 'A'
+
+        class Enum2(EnumBase): pass
+
+        class Enum2_1(Enum2):
+            B = 'B'
+
+        class Enum2_2(Enum2):
+            C = 'C'
+
+    and have all members be accessible on EnumBase (as well as have all members
+    of Enum2_1 and Enum2_2 be available on Enum2) as if they had been defined
+    there.
+
+    Non-leaf classes still may not have members directly defined on them, as
+    with standard enums.
+
+    Most of the usual enum magic methods are extended: __contains__, __dir__,
+    __getitem__, __getattr__, __iter__, __len__, and __reversed__. Only __new__
+    is not extended; instead, a new method `lookup` is provided. The
+    __members__ property is also extended.
+    """
+
+    def lookup(cls, value):
+        """Custom value lookup, which does recursive lookups on subclasses.
+
+        If this is a leaf enum class with defined members, this acts the same
+        as __new__().
+
+        But if this is a base class with no defined members of its own, it
+        tries doing a value lookup on all its subclasses until it finds the
+        value.
+
+        NOTE: Because of the implementation details of Enum, this must be a new
+        classmethod, and can't be implemented as __new__() [1].
+
+        [1] <https://docs.python.org/3.5/library/enum.html#finer-points>
+
+        :param value:
+            The value to look up. Can be a value, or an enum instance.
+        :type value:
+            `varies`
+        :raises:
+            :class:`ValueError` if the value isn't found anywhere.
+        """
+        try:
+            return cls(value)
+        except ValueError:
+            exc_info = sys.exc_info()
+            for subclass in cls.__subclasses__():
+                try:
+                    return subclass.lookup(value)
+                except ValueError:
+                    pass
+            # This needs to be `reraise()`, and not just `raise`. Otherwise,
+            # the inner exception from the previous line is re-raised, which
+            # isn't desired.
+            reraise(*exc_info)
+
+    @property
+    def __members__(cls):
+        members = OrderedDict(super(ExtendableEnumMeta, cls).__members__)
+        for subclass in cls.__subclasses__():
+            members.update(subclass.__members__)
+        return members
+
+    def __contains__(cls, member):
+        if super(ExtendableEnumMeta, cls).__contains__(member):
+            return True
+
+        def in_(subclass):
+            return member in subclass
+
+        return any(map(in_, cls.__subclasses__()))
+
+    def __dir__(cls):
+        return list(set(super(ExtendableEnumMeta, cls).__dir__()).union(set(map(dir, cls.__subclasses__()))))
+
+    def __getitem__(cls, name):
+        try:
+            return super(ExtendableEnumMeta, cls).__getitem__(name)
+        except KeyError:
+            exc_info = sys.exc_info()
+            for subclass in cls.__subclasses__():
+                try:
+                    return subclass[name]
+                except KeyError:
+                    pass
+            # This needs to be `reraise()`, and not just `raise`. Otherwise,
+            # the inner exception from the previous line is re-raised, which
+            # isn't desired.
+            reraise(*exc_info)
+
+    def __getattr__(cls, name):
+        try:
+            return super(ExtendableEnumMeta, cls).__getattr__(name)
+        except AttributeError:
+            exc_info = sys.exc_info()
+            try:
+                # If the super() call fails, don't call getattr() on all of the
+                # subclasses. Instead, use __getitem__ to do this. This is
+                # because we don't want to grab arbitrary attributes from
+                # subclasses, only enum members. For enum members, __getattr__
+                # and __getitem__ have the same behavior. And __getitem__ has
+                # the advantage of never grabbing anything other than enum
+                # members.
+                return cls[name]
+            except KeyError:
+                pass
+            # This needs to be `reraise()`, and not just `raise`. Otherwise,
+            # the inner exception from the previous line is re-raised, which
+            # isn't desired.
+            reraise(*exc_info)
+
+    def __iter__(cls):
+        return chain(super(ExtendableEnumMeta, cls).__iter__(), chain.from_iterable(map(iter, cls.__subclasses__())))
+
+    def __len__(cls):
+        return super(ExtendableEnumMeta, cls).__len__() + sum(map(len, cls.__subclasses__()))
+
+    def __reversed__(cls):
+        return reversed(list(cls))

--- a/boxsdk/util/text_enum.py
+++ b/boxsdk/util/text_enum.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 
-from __future__ import unicode_literals
+from __future__ import absolute_import, unicode_literals
 from enum import Enum
 from six import text_type
 

--- a/test/unit/object/test_events.py
+++ b/test/unit/object/test_events.py
@@ -1,13 +1,20 @@
 # coding: utf-8
 
 from __future__ import unicode_literals
+
+from itertools import chain
 import json
+
 from mock import Mock
 import pytest
 from requests.exceptions import Timeout
+from six.moves import map   # pylint:disable=redefined-builtin
+from six.moves.urllib.parse import urlencode, urlunsplit  # pylint:disable=import-error,no-name-in-module
+
 from boxsdk.network.default_network import DefaultNetworkResponse
-from boxsdk.object.events import Events
+from boxsdk.object.events import Events, EventsStreamType, UserEventsStreamType
 from boxsdk.session.box_session import BoxResponse
+from boxsdk.util.ordered_dict import OrderedDict
 
 
 @pytest.fixture()
@@ -25,6 +32,81 @@ def initial_stream_position():
     return 1348790499819
 
 
+# pylint:disable=no-member
+# pylint isn't currently smart enough to recognize the class member that was
+# added by the metaclass, when the metaclass was added by @add_metaclass() /
+# with_metaclass().
+STREAM_TYPES_AS_ENUM_INSTANCES = list(EventsStreamType.__members__.values())
+# pylint:enable=no-member
+STREAM_TYPES_AS_STRINGS = list(map(str, STREAM_TYPES_AS_ENUM_INSTANCES))
+
+
+def test_events_stream_type_extended_enum_class_has_expected_members():
+    assert len(STREAM_TYPES_AS_ENUM_INSTANCES) >= 4
+    assert len(STREAM_TYPES_AS_STRINGS) >= 4
+    assert 'all' in STREAM_TYPES_AS_STRINGS
+    assert 'changes' in STREAM_TYPES_AS_STRINGS
+    assert 'sync' in STREAM_TYPES_AS_STRINGS
+    assert 'admin_logs' in STREAM_TYPES_AS_STRINGS
+
+
+@pytest.fixture(
+    scope='session',
+    params=list(chain(
+        [None],   # Default behavior of not passing any stream_type
+        STREAM_TYPES_AS_ENUM_INSTANCES,   # Passing an enum instance
+        STREAM_TYPES_AS_STRINGS,  # Passing an enum value
+
+        # For forwards compatibility, make sure that it works to pass a string
+        # value that is not a member of the enum.
+        ['future_stream_type'],
+    )),
+)
+def stream_type_param(request):
+    """The value to pass as an Event method's stream_type parameter.
+
+    :return:
+        The parameter value, or `None` if no value should be passed.
+    :rtype:
+        :enum:`EventsStreamType` or `unicode` or `None`
+    """
+    return request.param
+
+
+@pytest.fixture()
+def expected_stream_type(stream_type_param):
+    """The stream type we expect to use.
+
+    :rtype:
+        `unicode`
+    """
+    if stream_type_param is None:
+        return UserEventsStreamType.ALL
+    return stream_type_param
+
+
+@pytest.fixture()
+def stream_type_kwargs(stream_type_param):
+    """The kwargs for stream_type to pass when invoking a method on `Events`.
+
+    :rtype:
+        `dict`
+    """
+    if stream_type_param:
+        return {'stream_type': stream_type_param}
+    return {}
+
+
+@pytest.fixture()
+def expected_stream_type_params(expected_stream_type):
+    """The stream_type-related params that we expect to pass to request methods.
+
+    :rtype:
+        :class:`OrderedDict`
+    """
+    return OrderedDict(stream_type=expected_stream_type)
+
+
 @pytest.fixture()
 def empty_events_response(final_stream_position):
     # pylint:disable=redefined-outer-name
@@ -39,8 +121,8 @@ def empty_events_response(final_stream_position):
 
 
 @pytest.fixture()
-def long_poll_url(test_url):
-    return test_url
+def long_poll_url(test_url, expected_stream_type_params):
+    return urlunsplit(('', '', test_url, urlencode(expected_stream_type_params), ''))
 
 
 @pytest.fixture()
@@ -49,10 +131,15 @@ def retry_timeout():
 
 
 @pytest.fixture()
-def options_response(long_poll_url, retry_timeout, make_mock_box_request):
+def options_response_entry(long_poll_url, retry_timeout):
+    return {'url': long_poll_url, 'retry_timeout': retry_timeout}
+
+
+@pytest.fixture()
+def options_response(options_response_entry, make_mock_box_request):
     # pylint:disable=redefined-outer-name
     mock_box_response, _ = make_mock_box_request(
-        response={'entries': [{'url': long_poll_url, 'retry_timeout': retry_timeout}]},
+        response={'entries': [options_response_entry]},
     )
     return mock_box_response
 
@@ -102,11 +189,37 @@ def events_response(initial_stream_position, mock_event, make_mock_box_request):
     return mock_box_response
 
 
-def test_get_events(test_events, mock_box_session, events_response):
+def test_get_events(
+        test_events,
+        mock_box_session,
+        events_response,
+        stream_type_kwargs,
+        expected_stream_type_params,
+):
     # pylint:disable=redefined-outer-name
+    expected_url = test_events.get_url()
     mock_box_session.get.return_value = events_response
-    events = test_events.get_events()
+    events = test_events.get_events(**stream_type_kwargs)
     assert 'next_stream_position' in events
+    mock_box_session.get.assert_any_call(
+        expected_url,
+        params=dict(limit=100, stream_position=0, **expected_stream_type_params),
+    )
+
+
+def test_get_long_poll_options(
+        mock_box_session,
+        test_events,
+        stream_type_kwargs,
+        expected_stream_type_params,
+        options_response,
+        options_response_entry,
+):
+    expected_url = test_events.get_url()
+    mock_box_session.options.return_value = options_response
+    long_poll_options = test_events.get_long_poll_options(**stream_type_kwargs)
+    mock_box_session.options.assert_called_with(expected_url, params=expected_stream_type_params)
+    assert long_poll_options == options_response_entry
 
 
 def test_generate_events_with_long_polling(
@@ -122,6 +235,9 @@ def test_generate_events_with_long_polling(
         reconnect_long_poll_response,
         max_retries_long_poll_response,
         mock_event,
+        stream_type_kwargs,
+        expected_stream_type,
+        expected_stream_type_params,
 ):
     # pylint:disable=redefined-outer-name
     expected_url = test_events.get_url()
@@ -136,17 +252,17 @@ def test_generate_events_with_long_polling(
         new_change_long_poll_response,
         empty_events_response,
     ]
-    events = test_events.generate_events_with_long_polling()
+    events = test_events.generate_events_with_long_polling(**stream_type_kwargs)
     assert next(events) == mock_event
     with pytest.raises(StopIteration):
         next(events)
     events.close()
-    mock_box_session.options.assert_called_with(expected_url)
-    mock_box_session.get.assert_any_call(expected_url, params={'stream_position': 'now'})
+    mock_box_session.options.assert_called_with(expected_url, params=expected_stream_type_params)
+    mock_box_session.get.assert_any_call(expected_url, params={'stream_position': 'now', 'limit': 0, 'stream_type': expected_stream_type})
     assert '/events' in expected_url
     mock_box_session.get.assert_any_call(
         expected_url,
-        params={'limit': 100, 'stream_type': 'all', 'stream_position': initial_stream_position},
+        params=dict(limit=100, stream_position=initial_stream_position, **expected_stream_type_params),
     )
     mock_box_session.get.assert_any_call(
         long_poll_url,

--- a/test/unit/util/test_enum.py
+++ b/test/unit/util/test_enum.py
@@ -1,0 +1,171 @@
+# coding: utf-8
+
+from __future__ import absolute_import, unicode_literals
+
+from enum import Enum
+import pytest
+from six import with_metaclass
+
+from boxsdk.util.enum import ExtendableEnumMeta
+from boxsdk.util.ordered_dict import OrderedDict
+
+
+# pylint:disable=invalid-name
+# So that we can have class definitions as pytest function fixtures.
+
+
+@pytest.fixture(scope='function')
+def EnumBase():
+
+    class EnumBase(with_metaclass(ExtendableEnumMeta, Enum)):
+        pass
+
+    return EnumBase
+
+
+@pytest.fixture(scope='function')
+def Enum1(EnumBase):
+
+    class Enum1(EnumBase):
+        A = 1
+
+    return Enum1
+
+
+@pytest.fixture(scope='function')
+def Enum2(EnumBase):
+
+    class Enum2(EnumBase):
+        pass
+
+    return Enum2
+
+
+@pytest.fixture(scope='function')
+def Enum2_1(Enum2):
+
+    class Enum2_1(Enum2):
+        B = 2
+
+    return Enum2_1
+
+
+@pytest.fixture(scope='function')
+def Enum2_2(Enum2):
+
+    class Enum2_2(Enum2):
+        C = 3
+
+    return Enum2_2
+
+
+@pytest.fixture(scope='function')
+def EnumBaseWithSubclassesDefined(EnumBase, Enum1, Enum2_1, Enum2_2):   # pylint:disable=unused-argument
+    return EnumBase
+
+
+enum_member_names = ['A', 'B', 'C']
+enum_member_values = [1, 2, 3]
+
+
+@pytest.fixture(scope='session', params=enum_member_names)
+def enum_member_name(request):
+    return request.param
+
+
+@pytest.fixture(scope='session', params=enum_member_values)
+def enum_member_value(request):
+    return request.param
+
+
+@pytest.fixture(scope='function')
+def enum_members(Enum1, Enum2_1, Enum2_2):
+    members = OrderedDict()
+    for enum_member_name, enum_class in zip(enum_member_names, [Enum1, Enum2_1, Enum2_2]):
+        members[enum_member_name] = enum_class[enum_member_name]
+    return members
+
+
+@pytest.fixture(scope='function')
+def enum_instance(enum_member_name, enum_members):
+    return enum_members[enum_member_name]
+
+
+def test_can_construct_enum_hierarchy(EnumBaseWithSubclassesDefined):   # pylint:disable=unused-argument
+    pass
+
+
+def test_can_not_construct_non_leaf_enum_with_members(Enum1):
+    with pytest.raises(TypeError):
+        class Enum1_1(Enum1):   # pylint:disable=unused-variable
+            pass
+
+
+def test_lookup(EnumBaseWithSubclassesDefined, enum_member_value):
+    EnumBase = EnumBaseWithSubclassesDefined
+    enum_instance = EnumBase.lookup(enum_member_value)
+    assert isinstance(enum_instance, EnumBase)
+    assert EnumBase.lookup(enum_instance) == enum_instance
+    assert enum_instance.__class__.lookup(enum_instance) == enum_instance
+    assert enum_instance.__class__(enum_instance) == enum_instance
+    assert enum_instance.__class__(enum_member_value) == enum_instance
+
+
+def test_lookup_raises_value_error_for_non_members(EnumBaseWithSubclassesDefined):
+    with pytest.raises(ValueError):
+        EnumBaseWithSubclassesDefined.lookup('foobar')
+
+
+def test_members(EnumBaseWithSubclassesDefined, enum_members):
+    assert dict(EnumBaseWithSubclassesDefined.__members__) == enum_members
+
+
+def test_contains_enum_instances(EnumBaseWithSubclassesDefined, enum_instance):
+    assert enum_instance in EnumBaseWithSubclassesDefined
+
+
+def test_contains_returns_false_for_non_instances(EnumBaseWithSubclassesDefined, enum_member_name):
+    assert enum_member_name not in EnumBaseWithSubclassesDefined
+
+
+def test_getitem(EnumBaseWithSubclassesDefined, enum_member_name, enum_instance):
+    assert EnumBaseWithSubclassesDefined[enum_member_name] == enum_instance
+
+
+def test_getitem_raises_key_error_for_non_member_names(EnumBaseWithSubclassesDefined, enum_member_value):
+    with pytest.raises(KeyError):
+        EnumBaseWithSubclassesDefined[enum_member_value]  # pylint:disable=pointless-statement
+
+
+def test_getattr(EnumBaseWithSubclassesDefined, enum_member_name, enum_instance):
+    assert getattr(EnumBaseWithSubclassesDefined, enum_member_name) == enum_instance
+
+
+def test_getattr_raises_attribute_error_for_non_member_names(EnumBaseWithSubclassesDefined):
+    with pytest.raises(AttributeError):
+        EnumBaseWithSubclassesDefined.foobar  # pylint:disable=pointless-statement
+
+
+def test_getattr_does_get_arbitrary_attributes_from_itself(EnumBaseWithSubclassesDefined):
+    EnumBase = EnumBaseWithSubclassesDefined
+    EnumBase.foobar = 'foobar'
+    assert EnumBase.foobar == 'foobar'
+
+
+def test_getattr_does_not_get_arbitrary_attributes_from_subclasses(EnumBaseWithSubclassesDefined, Enum1):
+    Enum1.foobar = 'foobar'
+    with pytest.raises(AttributeError):
+        EnumBaseWithSubclassesDefined.foobar  # pylint:disable=pointless-statement
+
+
+def test_iter(EnumBaseWithSubclassesDefined, enum_members):
+    assert list(EnumBaseWithSubclassesDefined) == list(enum_members.values())
+
+
+def test_len(EnumBaseWithSubclassesDefined, enum_members):
+    assert len(EnumBaseWithSubclassesDefined) == len(enum_members)
+
+
+def test_reversed(EnumBaseWithSubclassesDefined):
+    EnumBase = EnumBaseWithSubclassesDefined
+    assert list(reversed(list(reversed(EnumBase)))) == list(EnumBase)


### PR DESCRIPTION
Add a `stream_type` parameter to the `generate_events_with_long_polling()` method and its helper
methods. This allows users to listen to other event stream types. The default is still to listen to the 'all' stream.

In order to differentiate between user and enterprise event streams, the following enum hierarchy was created, with the help of a new `ExtendableEnumMeta` metaclass:

```
    +-- `EventsStreamType`
          |
          +-- `UserEventsStreamType`
          |
          +-- `EnterpriseEventsStreamType`
```

Unrelatedly, fix up the RST for the README. Add a table of contents, and fix up backticks (double-backticks are needed to create code spans, single-backticks aren't enough).