### PR TITLE
Additional changes for 1.4.2 release

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,6 +6,25 @@ Release History
 Upcoming
 ++++++++
 
+1.4.2 (2016-02-23)
+++++++++++++++++++
+
+- Make sure that ``__all__`` is only defined once, as a list of ``str``. Some
+  programs (e.g. PyInstaller) naively parse __init__.py files, and if
+  ``__all__`` is defined twice, the second one will be ignored. This can cause
+  ``__all__`` to appear as a list of ``unicode`` on Python 2.
+- Create wheel with correct conditional dependencies and license file.
+- Change the ``license`` meta-data from the full license text, to just a short
+  string, as specified in [1][2].
+
+  [1] <https://docs.python.org/3.5/distutils/setupscript.html#additional-meta-data>
+
+  [2] <https://www.python.org/dev/peps/pep-0459/#license>
+
+- Include entire test/ directory in source distribution. test/__init__.py was
+  previously missing.
+- Update documentation.
+
 1.4.1 (2016-02-11)
 ++++++++++++++++++
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,3 @@
 include README.rst LICENSE
+
+recursive-include test *

--- a/README.rst
+++ b/README.rst
@@ -301,6 +301,7 @@ instead use an instance of ``JWTAuth``.
         client_id='YOUR_CLIENT_ID',
         client_secret='YOUR_CLIENT_SECRET',
         enterprise_id='YOUR_ENTERPRISE_ID',
+        jwt_key_id='YOUR_JWT_KEY_ID',
         rsa_private_key_file_sys_path='CERT.PEM',
         store_tokens=your_store_tokens_callback_method,
     )
@@ -322,14 +323,15 @@ These users can then be authenticated:
 .. code-block:: python
 
     ned_auth = JWTAuth(
-       client_id='YOUR_CLIENT_ID',
-       client_secret='YOUR_CLIENT_SECRET',
-       enterprise_id='YOUR_ENTERPRISE_ID',
-       rsa_private_key_file_sys_path='CERT.PEM',
-       store_tokens=your_store_tokens_callback_method,
-   )
-   ned_auth.authenticate_app_user(ned_stark_user)
-   ned_client = Client(ned_auth)
+        client_id='YOUR_CLIENT_ID',
+        client_secret='YOUR_CLIENT_SECRET',
+        enterprise_id='YOUR_ENTERPRISE_ID',
+        jwt_key_id='YOUR_JWT_KEY_ID',
+        rsa_private_key_file_sys_path='CERT.PEM',
+        store_tokens=your_store_tokens_callback_method,
+    )
+    ned_auth.authenticate_app_user(ned_stark_user)
+    ned_client = Client(ned_auth)
 
 Requests made with ``ned_client`` (or objects returned from ``ned_client``'s methods)
 will be performed on behalf of the newly created app user.

--- a/boxsdk/exception.py
+++ b/boxsdk/exception.py
@@ -9,6 +9,8 @@ class BoxException(Exception):
     Base class exception for all errors raised from the SDK.
     """
     def __str__(self):
+        # pylint:disable=no-member
+        # <https://github.com/box/box-python-sdk/issues/117>
         return self.__unicode__().encode('utf-8') if PY2 else self.__unicode__()
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,3 +3,6 @@
 # 3. If at all possible, it is good practice to do this. If you cannot, you
 # will need to generate wheels for each Python version that you support.
 universal=1
+
+[metadata]
+license_file=LICENSE

--- a/setup.py
+++ b/setup.py
@@ -2,10 +2,10 @@
 
 from __future__ import unicode_literals
 
+from codecs import open   # pylint:disable=redefined-builtin
+from collections import defaultdict
 from os.path import dirname, join
-import platform
 import sys
-from sys import version_info
 
 from setuptools import setup, find_packages
 from setuptools.command.test import test as TestCommand
@@ -32,6 +32,8 @@ CLASSIFIERS = [
 
 
 class PyTest(TestCommand):
+    # pylint:disable=attribute-defined-outside-init
+
     user_options = [(b'pytest-args=', b'a', b"Arguments to pass to py.test")]
 
     def initialize_options(self):
@@ -55,26 +57,45 @@ def main():
     install_requires = ['requests>=2.4.3', 'six>=1.4.0', 'requests-toolbelt>=0.4.0']
     redis_requires = ['redis>=2.10.3']
     jwt_requires = ['pyjwt>=1.3.0', 'cryptography>=0.9.2']
-    if version_info < (3, 4):
-        install_requires.append('enum34>=1.0.4')
-    elif version_info < (2, 7):
-        install_requires.append('ordereddict>=1.1')
+    extra_requires = defaultdict(list)
+    extra_requires.update({'jwt': jwt_requires, 'redis': redis_requires, 'all': jwt_requires + redis_requires})
+    conditional_dependencies = {
+        # Newer versions of pip and wheel, which support PEP 426, allow
+        # environment markers for conditional dependencies to use operators
+        # such as `<` and `<=` [1]. However, older versions of pip and wheel
+        # only support PEP 345, which only allows operators `==` and `in` (and
+        # their negations) along with string constants [2]. To get the widest
+        # range of support, we'll only use the `==` operator, which means
+        # explicitly listing all supported Python versions that need the extra
+        # dependencies.
+        #
+        # [1] <https://www.python.org/dev/peps/pep-0426/#environment-markers>
+        # [2] <https://www.python.org/dev/peps/pep-0345/#environment-markers>
+        'enum34>=1.0.4': ['2.6', '2.7', '3.3'],   # <'3.4'
+        'ordereddict>=1.1': ['2.6'],   # <'2.7'
+    }
+    for requirement, python_versions in conditional_dependencies.items():
+        for python_version in python_versions:
+            # <https://wheel.readthedocs.org/en/latest/#defining-conditional-dependencies>
+            python_conditional = 'python_version=="{0}"'.format(python_version)
+            key = ':{0}'.format(python_conditional)
+            extra_requires[key].append(requirement)
     setup(
         name='boxsdk',
         version='1.4.2',
         description='Official Box Python SDK',
-        long_description=open(join(base_dir, 'README.rst')).read(),
+        long_description=open(join(base_dir, 'README.rst'), encoding='utf-8').read(),
         author='Box',
         author_email='oss@box.com',
         url='http://opensource.box.com',
-        packages=find_packages(exclude=['demo', 'docs', 'test']),
+        packages=find_packages(exclude=['demo', 'docs', 'test', 'test*', '*test', '*test*']),
         install_requires=install_requires,
-        extras_require={'jwt': jwt_requires, 'redis': redis_requires, 'all': jwt_requires + redis_requires},
+        extras_require=extra_requires,
         tests_require=['pytest', 'pytest-xdist', 'mock', 'sqlalchemy', 'bottle', 'jsonpatch'],
         cmdclass={'test': PyTest},
         classifiers=CLASSIFIERS,
         keywords='box oauth2 sdk',
-        license=open(join(base_dir, 'LICENSE')).read(),
+        license='Apache Software License, Version 2.0, http://www.apache.org/licenses/LICENSE-2.0',
     )
 
 

--- a/test/functional/conftest.py
+++ b/test/functional/conftest.py
@@ -8,7 +8,7 @@ from mock import patch
 import pytest
 import requests
 import six
-from six.moves.urllib import parse  # pylint:disable=import-error, no-name-in-module
+from six.moves.urllib import parse  # pylint:disable=import-error, no-name-in-module,wrong-import-order
 
 from boxsdk.auth.oauth2 import OAuth2
 from boxsdk.config import API

--- a/test/unit/auth/test_oauth2.py
+++ b/test/unit/auth/test_oauth2.py
@@ -8,7 +8,7 @@ from threading import Thread
 
 from mock import Mock
 import pytest
-from six.moves.urllib import parse as urlparse  # pylint:disable=import-error,no-name-in-module
+from six.moves.urllib import parse as urlparse  # pylint:disable=import-error,no-name-in-module,wrong-import-order
 
 from boxsdk.exception import BoxOAuthException
 from boxsdk.network.default_network import DefaultNetworkResponse

--- a/tox.ini
+++ b/tox.ini
@@ -33,14 +33,14 @@ commands =
 
 [testenv:pep8]
 commands = 
-  pep8 --ignore=E501,W292 boxsdk
+  pep8 --ignore=E501,W292 boxsdk setup.py
   pep8 --ignore=E501,W292 test
 deps = 
   pep8
 
 [testenv:pylint]
 commands =
-  pylint --rcfile=.pylintrc boxsdk
+  pylint --rcfile=.pylintrc boxsdk setup.py
   # pylint:disable W0621(redefined-outer-name) - Using py.test fixtures always breaks this rule.
   pylint --rcfile=.pylintrc test -d W0621 --ignore=mock_box
 deps = -rrequirements-dev.txt


### PR DESCRIPTION
Create wheel with correct conditional dependencies and license file.

Change the ``license`` meta-data from the full license text, to just a short string, as specified in [1][2].

Include entire test/ directory in source distribution. test/__init__.py was previously missing.

Update documentation. Fixes #112.

Use utf-8 encoding to open README in setup.py.

Run pep8 and pylint on setup.py.

Update pylint directives.

[1] <https://docs.python.org/3.5/distutils/setupscript.html#additional-meta-data>
[2] <https://www.python.org/dev/peps/pep-0459/#license>