### PR TITLE
Add revoke() method to OAuth2 class.

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,6 +6,10 @@ Release History
 Upcoming
 ++++++++
 
+1.5.1 (2016-03-23)
+++++++++++++++++++
+
+- Added a ``revoke()`` method to the ``OAuth2`` class. Calling it will revoke the current access/refresh token pair.
 
 
 1.5.0 (2016-03-17)

--- a/boxsdk/auth/developer_token_auth.py
+++ b/boxsdk/auth/developer_token_auth.py
@@ -32,3 +32,9 @@ class DeveloperTokenAuth(OAuth2):
         """
         self._access_token = self._refresh_developer_token()
         return self._access_token, None
+
+    def revoke(self):
+        """
+        Base class override.
+        Do nothing; developer tokens can't be revoked without client ID and secret.
+        """

--- a/boxsdk/auth/oauth2.py
+++ b/boxsdk/auth/oauth2.py
@@ -275,7 +275,7 @@ class OAuth2(object):
                     'client_secret': self._client_secret,
                     'token': token_to_revoke,
                 },
-                access_token=token_to_revoke,
+                access_token=access_token,
             )
             if not network_response.ok:
                 raise BoxOAuthException(network_response.status_code, network_response.content, url, 'POST')

--- a/boxsdk/auth/oauth2.py
+++ b/boxsdk/auth/oauth2.py
@@ -262,7 +262,8 @@ class OAuth2(object):
         Revoke the authorization for the current access/refresh token pair.
         """
         with self._refresh_lock:
-            token_to_revoke, _ = self._get_tokens()
+            access_token, refresh_token = self._get_tokens()
+            token_to_revoke = access_token or refresh_token
             if token_to_revoke is None:
                 return
             url = '{base_auth_url}/revoke'.format(base_auth_url=API.OAUTH2_API_URL)

--- a/boxsdk/version.py
+++ b/boxsdk/version.py
@@ -3,4 +3,4 @@
 from __future__ import unicode_literals, absolute_import
 
 
-__version__ = '1.5.0'
+__version__ = '1.5.1'

--- a/test/unit/auth/test_oauth2.py
+++ b/test/unit/auth/test_oauth2.py
@@ -311,6 +311,6 @@ def test_revoke_sends_revoke_request(
             'client_secret': client_secret,
             'token': expected_token_to_revoke,
         },
-        access_token=expected_token_to_revoke,
+        access_token=access_token,
     )
     assert oauth.access_token is None

--- a/test/unit/auth/test_oauth2.py
+++ b/test/unit/auth/test_oauth2.py
@@ -275,3 +275,28 @@ def test_token_request_allows_missing_refresh_token(mock_network_layer):
         network_layer=mock_network_layer,
     )
     oauth.send_token_request({}, access_token=None, expect_refresh_token=False)
+
+
+def test_revoke_sends_revoke_request(client_id, client_secret, mock_network_layer):
+    fake_access_token = 'fake_access_token'
+    mock_network_response = Mock()
+    mock_network_response.ok = True
+    mock_network_layer.request.return_value = mock_network_response
+    oauth = OAuth2(
+        client_id=client_id,
+        client_secret=client_secret,
+        access_token=fake_access_token,
+        network_layer=mock_network_layer,
+    )
+    oauth.revoke()
+    mock_network_layer.request.assert_called_once_with(
+        'POST',
+        '{0}/revoke'.format(API.OAUTH2_API_URL),
+        data={
+            'client_id': client_id,
+            'client_secret': client_secret,
+            'token': fake_access_token,
+        },
+        access_token=fake_access_token,
+    )
+    assert oauth.access_token is None

--- a/test/unit/auth/test_oauth2.py
+++ b/test/unit/auth/test_oauth2.py
@@ -277,15 +277,29 @@ def test_token_request_allows_missing_refresh_token(mock_network_layer):
     oauth.send_token_request({}, access_token=None, expect_refresh_token=False)
 
 
-def test_revoke_sends_revoke_request(client_id, client_secret, mock_network_layer):
-    fake_access_token = 'fake_access_token'
+@pytest.mark.parametrize(
+    'access_token,refresh_token,expected_token_to_revoke',
+    (
+        ('fake_access_token', 'fake_refresh_token', 'fake_access_token'),
+        (None, 'fake_refresh_token', 'fake_refresh_token')
+    )
+)
+def test_revoke_sends_revoke_request(
+        client_id,
+        client_secret,
+        mock_network_layer,
+        access_token,
+        refresh_token,
+        expected_token_to_revoke,
+):
     mock_network_response = Mock()
     mock_network_response.ok = True
     mock_network_layer.request.return_value = mock_network_response
     oauth = OAuth2(
         client_id=client_id,
         client_secret=client_secret,
-        access_token=fake_access_token,
+        access_token=access_token,
+        refresh_token=refresh_token,
         network_layer=mock_network_layer,
     )
     oauth.revoke()
@@ -295,8 +309,8 @@ def test_revoke_sends_revoke_request(client_id, client_secret, mock_network_laye
         data={
             'client_id': client_id,
             'client_secret': client_secret,
-            'token': fake_access_token,
+            'token': expected_token_to_revoke,
         },
-        access_token=fake_access_token,
+        access_token=expected_token_to_revoke,
     )
     assert oauth.access_token is None


### PR DESCRIPTION
Fixes #124

The Box API includes a /revoke endpoint to de-auth tokens.
This commit makes it easy to use this endpoint with the SDK.