### PR TITLE
Fixes to JWTAuth

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,7 +6,12 @@ Release History
 Upcoming
 ++++++++
 
-1.5.2
+1.5.3
+++++++++++++++++++
+
+- Bugfix so that ``JWTAuth`` opens the PEM private key file in ``'rb'`` mode.
+
+1.5.2 (2016-05-19)
 ++++++++++++++++++
 
 - Bugfix so that ``OAuth2`` always has the correct tokens after a call to ``refresh()``.

--- a/boxsdk/auth/jwt_auth.py
+++ b/boxsdk/auth/jwt_auth.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 
-from __future__ import unicode_literals
+from __future__ import absolute_import, unicode_literals
 
 from datetime import datetime, timedelta
 import random
@@ -95,7 +95,7 @@ class JWTAuth(OAuth2):
             refresh_token=None,
             network_layer=network_layer,
         )
-        with open(rsa_private_key_file_sys_path) as key_file:
+        with open(rsa_private_key_file_sys_path, 'rb') as key_file:
             self._rsa_private_key = serialization.load_pem_private_key(
                 key_file.read(),
                 password=rsa_private_key_passphrase,
@@ -182,6 +182,7 @@ class JWTAuth(OAuth2):
         :rtype:
             `unicode`
         """
+        self._user_id = None
         return self._auth_with_jwt(self._enterprise_id, 'enterprise')
 
     def _refresh(self, access_token):

--- a/boxsdk/version.py
+++ b/boxsdk/version.py
@@ -3,4 +3,4 @@
 from __future__ import unicode_literals, absolute_import
 
 
-__version__ = '1.5.2'
+__version__ = '1.5.3'

--- a/test/unit/auth/test_jwt_auth.py
+++ b/test/unit/auth/test_jwt_auth.py
@@ -73,7 +73,7 @@ def jwt_auth_init_mocks(
     }
 
     mock_network_layer.request.return_value = successful_token_response
-    key_file_read_data = 'key_file_read_data'
+    key_file_read_data = b'key_file_read_data'
     with patch('boxsdk.auth.jwt_auth.open', mock_open(read_data=key_file_read_data), create=True) as jwt_auth_open:
         with patch('cryptography.hazmat.primitives.serialization.load_pem_private_key') as load_pem_private_key:
             oauth = JWTAuth(
@@ -88,7 +88,7 @@ def jwt_auth_init_mocks(
                 jwt_key_id=jwt_key_id,
             )
 
-            jwt_auth_open.assert_called_once_with(sentinel.rsa_path)
+            jwt_auth_open.assert_called_once_with(sentinel.rsa_path, 'rb')
             jwt_auth_open.return_value.read.assert_called_once_with()  # pylint:disable=no-member
             load_pem_private_key.assert_called_once_with(
                 key_file_read_data,


### PR DESCRIPTION
Open the PEM private key file in 'rb' mode so that `.read()` returns `bytes` in Python 3. Otherwise, the default `openssl` backend of `cryptography` fails to use the key.

Set the `_user_id` attribute to `None` when authenticating an enterprise instance.

Fixes #136.

cc @makiten 