### PR TITLE
Allow custom subclasses of smart objects

### DIFF
--- a/boxsdk/auth/jwt_auth.py
+++ b/boxsdk/auth/jwt_auth.py
@@ -10,8 +10,8 @@ from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import serialization
 import jwt
 
-from .oauth2 import OAuth2
 from boxsdk.util.compat import total_seconds
+from .oauth2 import OAuth2
 
 
 class JWTAuth(OAuth2):

--- a/boxsdk/object/file.py
+++ b/boxsdk/object/file.py
@@ -127,7 +127,7 @@ class File(Item):
 
         files = {'file': ('unused', file_stream)}
         headers = {'If-Match': etag} if etag is not None else None
-        return File(
+        return self.__class__(
             session=self._session,
             object_id=self._object_id,
             response_object=self._session.post(url, expect_json_response=False, files=files, headers=headers).json(),

--- a/boxsdk/object/folder.py
+++ b/boxsdk/object/folder.py
@@ -6,8 +6,6 @@ import os
 from six import text_type
 
 from boxsdk.config import API
-from boxsdk.object.collaboration import Collaboration
-from boxsdk.object.file import File
 from boxsdk.object.group import Group
 from boxsdk.object.item import Item
 from boxsdk.object.user import User
@@ -217,7 +215,7 @@ class Folder(Item):
         box_response = self._session.post(url, data=data, files=files, expect_json_response=False)
         file_response = box_response.json()['entries'][0]
         file_id = file_response['id']
-        return File(
+        return Translator().translate(file_response['type'])(
             session=self._session,
             object_id=file_id,
             response_object=file_response,
@@ -296,7 +294,7 @@ class Folder(Item):
         }
         box_response = self._session.post(url, data=json.dumps(data))
         response = box_response.json()
-        return Folder(
+        return self.__class__(
             session=self._session,
             object_id=response['id'],
             response_object=response,
@@ -359,7 +357,7 @@ class Folder(Item):
         box_response = self._session.post(url, expect_json_response=True, data=data, params=params)
         collaboration_response = box_response.json()
         collab_id = collaboration_response['id']
-        return Collaboration(
+        return Translator().translate(collaboration_response['type'])(
             session=self._session,
             object_id=collab_id,
             response_object=collaboration_response,

--- a/boxsdk/object/group.py
+++ b/boxsdk/object/group.py
@@ -1,12 +1,12 @@
 # coding: utf-8
 
-from __future__ import unicode_literals
+from __future__ import unicode_literals, absolute_import
 from functools import partial
 import json
 
 from .base_object import BaseObject
-from boxsdk.config import API
-from boxsdk.util.translator import Translator
+from ..config import API
+from ..util.translator import Translator
 
 
 class Group(BaseObject):

--- a/boxsdk/object/group.py
+++ b/boxsdk/object/group.py
@@ -6,7 +6,7 @@ import json
 
 from .base_object import BaseObject
 from boxsdk.config import API
-from boxsdk.object.group_membership import GroupMembership
+from boxsdk.util.translator import Translator
 
 
 class Group(BaseObject):
@@ -46,7 +46,7 @@ class Group(BaseObject):
         """
         url = self.get_url('memberships')
 
-        membership_factory = partial(GroupMembership, group=self)
+        membership_factory = partial(Translator().translate("group_membership"), group=self)
         for group_membership_tuple in self._paging_wrapper(url, starting_index, limit, membership_factory):
             if include_page_info:
                 yield group_membership_tuple
@@ -80,4 +80,4 @@ class Group(BaseObject):
         box_response = self._session.post(url, data=json.dumps(body_attributes))
         response = box_response.json()
 
-        return GroupMembership(self._session, response['id'], response, user=user, group=self)
+        return Translator().translate(response['type'])(self._session, response['id'], response, user=user, group=self)

--- a/boxsdk/object/group_membership.py
+++ b/boxsdk/object/group_membership.py
@@ -1,9 +1,9 @@
 # coding: utf-8
 
-from __future__ import unicode_literals
+from __future__ import unicode_literals, absolute_import
 
 from .base_object import BaseObject
-from boxsdk.util.translator import Translator
+from ..util.translator import Translator
 
 
 class GroupMembership(BaseObject):

--- a/boxsdk/object/item.py
+++ b/boxsdk/object/item.py
@@ -4,8 +4,8 @@ from __future__ import unicode_literals, absolute_import
 import json
 
 from .base_object import BaseObject
-from boxsdk.config import API
-from boxsdk.exception import BoxAPIException
+from ..config import API
+from ..exception import BoxAPIException
 
 
 class Item(BaseObject):

--- a/boxsdk/object/search.py
+++ b/boxsdk/object/search.py
@@ -1,11 +1,11 @@
 # coding: utf-8
 
-from __future__ import unicode_literals
+from __future__ import unicode_literals, absolute_import
 
 import json
 
 from .base_endpoint import BaseEndpoint
-from boxsdk.util.translator import Translator
+from ..util.translator import Translator
 
 
 class MetadataSearchFilter(object):


### PR DESCRIPTION
Enabled `Translator` to register new subclasses of smart objects.  Removed all hard coded smart object return types in favor of a lookup in `Translator` or returning an instance of `self.__class__`.