### PR TITLE
Changed base_object so it can be compared to None object

### DIFF
--- a/boxsdk/object/base_object.py
+++ b/boxsdk/object/base_object.py
@@ -153,7 +153,7 @@ class BaseObject(BaseEndpoint, BaseAPIJSONObject):
 
     def __eq__(self, other):
         """Equality as determined by object id"""
-        return self._object_id == other.object_id
+        return (other != None) and (self._object_id == other.object_id)
 
     def _paging_wrapper(self, url, starting_index, limit, factory=None):
         """

--- a/boxsdk/object/base_object.py
+++ b/boxsdk/object/base_object.py
@@ -153,7 +153,7 @@ class BaseObject(BaseEndpoint, BaseAPIJSONObject):
 
     def __eq__(self, other):
         """Equality as determined by object id"""
-        return (other != None) and (self._object_id == other.object_id)
+        return (other is not None) and (self._object_id == other.object_id)
 
     def _paging_wrapper(self, url, starting_index, limit, factory=None):
         """


### PR DESCRIPTION
Changed __eq__ comparison to allow an object to be compared to None in addition to another object by id.   The current code requires that it be compared against another instantiated object.
