### PR TITLE
Register subclasses

### DIFF
--- a/boxsdk/auth/jwt_auth.py
+++ b/boxsdk/auth/jwt_auth.py
@@ -10,8 +10,8 @@ from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import serialization
 import jwt
 
-from boxsdk.util.compat import total_seconds
 from .oauth2 import OAuth2
+from ..util.compat import total_seconds
 
 
 class JWTAuth(OAuth2):

--- a/boxsdk/client/client.py
+++ b/boxsdk/client/client.py
@@ -138,7 +138,8 @@ class Client(object):
             params['filter_term'] = filter_term
         box_response = self._session.get(url, params=params)
         response = box_response.json()
-        return [Translator().translate('user')(
+        User = Translator().translate('user')
+        return [User(
             session=self._session,
             object_id=item['id'],
             response_object=item,
@@ -242,10 +243,11 @@ class Client(object):
         url = '{0}/groups'.format(API.BASE_API_URL)
         box_response = self._session.get(url)
         response = box_response.json()
-        return [Translator().translate('group')(
+        Group = Translator().translate('group')
+        return [Group(
             session=self._session,
             object_id=item['id'],
-            response_object=item
+            response_object=item,
         ) for item in response['entries']]
 
     def create_group(self, name):
@@ -352,7 +354,7 @@ class Client(object):
             user_attributes['is_platform_access_only'] = True
         box_response = self._session.post(url, data=json.dumps(user_attributes))
         response = box_response.json()
-        return Translator().translate(response['type'])(
+        return Translator().translate('user')(
             session=self._session,
             object_id=response['id'],
             response_object=response,

--- a/boxsdk/client/client.py
+++ b/boxsdk/client/client.py
@@ -138,8 +138,8 @@ class Client(object):
             params['filter_term'] = filter_term
         box_response = self._session.get(url, params=params)
         response = box_response.json()
-        User = Translator().translate('user')
-        return [User(
+        user_class = Translator().translate('user')
+        return [user_class(
             session=self._session,
             object_id=item['id'],
             response_object=item,
@@ -243,8 +243,8 @@ class Client(object):
         url = '{0}/groups'.format(API.BASE_API_URL)
         box_response = self._session.get(url)
         response = box_response.json()
-        Group = Translator().translate('group')
-        return [Group(
+        group_class = Translator().translate('group')
+        return [group_class(
             session=self._session,
             object_id=item['id'],
             response_object=item,

--- a/boxsdk/object/base_api_json_object.py
+++ b/boxsdk/object/base_api_json_object.py
@@ -15,7 +15,7 @@ class BaseAPIJSONObjectMeta(type):
     """
     def __init__(cls, name, bases, attrs):
         super(BaseAPIJSONObjectMeta, cls).__init__(name, bases, attrs)
-        item_type = attrs.get('_item_type', None)
+        item_type = getattr(cls, '_item_type', None)
         if item_type is not None:
             Translator().register(item_type, cls)
 


### PR DESCRIPTION
Enable custom subclasses of smart objects to be registered correctly with the `Translator`.