### PR TITLE
Prepare for next 2.0.0 alpha release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ matrix:
       env: TOX_ENV=py34
     - python: 3.5
       env: TOX_ENV=py35
-    - python: "3.6-dev"
+    - python: 3.6
       env: TOX_ENV=py36
     - python: pypy
       env: TOX_ENV=pypy PYPY_VERSION='4.0.0'

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -42,8 +42,8 @@ if [[ "$(uname -s)" == 'Darwin' ]]; then
             pyenv global 3.5.0
             ;;
         py36)
-            pyenv install 3.6-dev
-            pyenv global 3.6-dev
+            pyenv install 3.6.0
+            pyenv global 3.6.0
             ;;
         pypy)
             pyenv install "pypy-${PYPY_VERSION}"

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -74,6 +74,10 @@ Release History
 - Added an ``Event`` class.
 - Moved ``metadata()`` method to ``Item`` so it's now available for ``Folder``
   as well as ``File``.
+- The ``BaseAPIJSONObject`` baseclass (which is a superclass of all API
+  response objects) now supports ``__contains__`` and ``__iter__``. They behave
+  the same as for ``Mapping``. That is, ``__contains__`` checks for JSON keys
+  in the object, and ``__iter__`` yields all of the object's keys.
 
 **Other**
 

--- a/boxsdk/version.py
+++ b/boxsdk/version.py
@@ -3,4 +3,4 @@
 from __future__ import unicode_literals, absolute_import
 
 
-__version__ = '2.0.0a3'
+__version__ = '2.0.0a4'


### PR DESCRIPTION
Bump version to 2.0.0a4.

Add new release notes.

Start running tests against the final build of Python 3.6.0
(instead of the development branch).