### PR TITLE
Fix auth refresh for clients using JWTAuth (#197)

### DIFF
--- a/boxsdk/auth/jwt_auth.py
+++ b/boxsdk/auth/jwt_auth.py
@@ -192,7 +192,7 @@ class JWTAuth(OAuth2):
             data['box_device_id'] = self._box_device_id
         if self._box_device_name:
             data['box_device_name'] = self._box_device_name
-        return self.send_token_request(data, access_token=None, expect_refresh_token=False)[0]
+        return self.send_token_request(data, access_token=None, expect_refresh_token=False)
 
     def authenticate_user(self, user=None):
         """


### PR DESCRIPTION
This will ensure that the return value is the expected tuple of (access_token, refresh_token), and not just access_token.