### PR TITLE
Add Collection object and collections()/get_favorites() to Client

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -9,3 +9,4 @@ used to interact with the Box API. This is a list of contributors.
 - `@nsundareswaran <https://github.com/nsundareswaran>`_
 - `@kelseymorris95 <https://github.com/kelseymorris95>`_
 - `@sp4x <https://github.com/sp4x>`_
+- `@josephroque <https://github.com/josephroque>`_

--- a/boxsdk/object/__init__.py
+++ b/boxsdk/object/__init__.py
@@ -5,4 +5,4 @@ from __future__ import unicode_literals
 from six.moves import map   # pylint:disable=redefined-builtin
 
 
-__all__ = list(map(str, ['collaboration', 'events', 'event', 'file', 'folder', 'group', 'group_membership', 'search', 'user']))
+__all__ = list(map(str, ['collaboration', 'collection', 'events', 'event', 'file', 'folder', 'group', 'group_membership', 'search', 'user']))

--- a/boxsdk/object/collection.py
+++ b/boxsdk/object/collection.py
@@ -1,0 +1,78 @@
+# coding: utf-8
+
+from __future__ import unicode_literals, absolute_import
+import json
+
+from .base_object import BaseObject
+from ..config import API
+from ..util.api_call_decorator import api_call
+
+
+class Collection(BaseObject):
+    """Represents a single Box collection."""
+
+    _item_type = 'collection'
+
+    @api_call
+    def add_item(self, item):
+        """
+        Add an item to this collection.
+
+        :param item:
+            The Item to add to the collection
+        :type item:
+            :class:`Item`
+        :returns:
+            The new Item instance
+        :rtype:
+            :class:`Item`
+        """
+        return item.add_to_collection(self)
+
+    @api_call
+    def remove_item(self, item):
+        """
+        Remove an item from this collection. Only the favorites collection is supported, so all collections are removed.
+
+        :param item:
+            The Item to remove from the collection
+        :type item:
+            :class:`Item`
+        :returns:
+            The new Item instance
+        :rtype:
+            :class:`Item`
+        """
+        return item.remove_from_collection(self)
+
+    @api_call
+    def get_items(self, limit=100, offset=0, fields=None):
+        """Get the items in this collection.
+
+        :param limit:
+            The maximum number of items to return.
+        :type limit:
+            `int`
+        :param offset:
+            The index at which to start returning items.
+        :type offset:
+            `int`
+        :param fields:
+            List of fields to request.
+        :type fields:
+            `Iterable` of `unicode`
+        :returns:
+            A list of items in the collection.
+        :rtype:
+            `list` of :class:`Item`
+        """
+        url = self.get_url('items')
+        params = {
+            'limit': limit,
+            'offset': offset,
+        }
+        if fields:
+            params['fields'] = ','.join(fields)
+        box_response = self._session.get(url, params=params)
+        response = box_response.json()
+        return [self.translator.translate(item['type'])(self._session, item['id'], item) for item in response['entries']]

--- a/boxsdk/object/item.py
+++ b/boxsdk/object/item.py
@@ -317,6 +317,52 @@ class Item(BaseObject):
         return item.shared_link is None  # pylint:disable=no-member
 
     @api_call
+    def add_to_collection(self, collection, etag=None):
+        """
+        Add this item to a collection.
+
+        :param collection:
+            The collection the item will be added to.
+        :type collection:
+            :class:`Collection`
+        :param etag:
+            If specified, instruct the Box API to add to the collection only if the current version's etag matches.
+        :type etag:
+            `unicode` or None
+        :returns:
+            The update object
+        :rtype:
+            :class:`Item`
+        """
+        data = {
+            'collections': [{ 'id': collection.object_id }]
+        }
+        return self.update_info(data, etag)
+
+    @api_call
+    def remove_from_collection(self, collection, etag=None):
+        """
+        Remove this item from a collection. Only the favorites collection is supported, so all collections are removed.
+
+        :param collection:
+            The collection the item will be removed from.
+        :type collection:
+            :class:`Collection`
+        :param etag:
+            If specified, instruct the Box API to remove from the collection only if the current version's etag matches.
+        :type etag:
+            `unicode` or None
+        :returns:
+            The update object
+        :rtype:
+            :class:`Item`
+        """
+        data = {
+            'collections': []
+        }
+        return self.update_info(data, etag)
+
+    @api_call
     def delete(self, params=None, etag=None):
         """Delete the item.
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -252,6 +252,11 @@ def mock_object_id():
 
 
 @pytest.fixture(scope='module')
+def mock_collection_id():
+    return 'fake-collection'
+
+
+@pytest.fixture(scope='module')
 def mock_user_id():
     return 'fake-user-100'
 

--- a/test/unit/object/conftest.py
+++ b/test/unit/object/conftest.py
@@ -7,6 +7,7 @@ from mock import Mock
 import pytest
 from six import int2byte, PY2
 from boxsdk.object.collaboration import Collaboration
+from boxsdk.object.collection import Collection
 from boxsdk.object.file import File
 from boxsdk.object.folder import Folder
 from boxsdk.object.group import Group
@@ -52,6 +53,9 @@ def mock_upload_response(mock_object_id, make_mock_box_request):
 def test_collaboration(mock_box_session, mock_collaboration_id):
     return Collaboration(mock_box_session, mock_collaboration_id)
 
+@pytest.fixture()
+def test_collection(mock_box_session, mock_collection_id):
+    return Collection(mock_box_session, mock_collection_id)
 
 @pytest.fixture()
 def test_file(mock_box_session, mock_object_id):

--- a/test/unit/object/test_collection.py
+++ b/test/unit/object/test_collection.py
@@ -1,0 +1,78 @@
+# coding: utf-8
+
+from __future__ import unicode_literals
+import json
+from mock import Mock
+import pytest
+from six.moves import zip  # pylint:disable=redefined-builtin,import-error
+from boxsdk.network.default_network import DefaultNetworkResponse
+from boxsdk.object.file import File
+from boxsdk.object.folder import Folder
+from boxsdk.session.box_session import BoxResponse
+
+
+# pylint:disable=protected-access
+# pylint:disable=redefined-outer-name
+
+
+@pytest.fixture()
+def mock_items(mock_box_session, mock_object_id):
+    return [
+        {'type': 'file', 'id': mock_object_id},
+        {'type': 'folder', 'id': mock_object_id},
+        {'type': 'file', 'id': mock_object_id},
+    ], [
+        File(mock_box_session, mock_object_id),
+        Folder(mock_box_session, mock_object_id),
+        File(mock_box_session, mock_object_id),
+    ]
+
+
+@pytest.fixture()
+def mock_items_response(mock_items):
+    # pylint:disable=redefined-outer-name
+    def get_response(limit, offset):
+        items_json, items = mock_items
+        mock_box_response = Mock(BoxResponse)
+        mock_network_response = Mock(DefaultNetworkResponse)
+        mock_box_response.network_response = mock_network_response
+        mock_box_response.json.return_value = mock_json = {'entries': items_json[offset:limit + offset]}
+        mock_box_response.content = json.dumps(mock_json).encode()
+        mock_box_response.status_code = 200
+        mock_box_response.ok = True
+        return mock_box_response, items[offset:limit + offset]
+    return get_response
+
+
+@pytest.mark.parametrize('limit,offset,fields', [(1, 0, None), (100, 0, ['foo', 'bar']), (1, 1, None)])
+def test_get_items(test_collection, mock_box_session, mock_items_response, limit, offset, fields):
+    # pylint:disable=redefined-outer-name
+    expected_url = test_collection.get_url('items')
+    mock_box_session.get.return_value, expected_items = mock_items_response(limit, offset)
+    items = test_collection.get_items(limit, offset, fields)
+    expected_params = {'limit': limit, 'offset': offset}
+    if fields:
+        expected_params['fields'] = ','.join(fields)
+    mock_box_session.get.assert_called_once_with(expected_url, params=expected_params)
+    assert items == expected_items
+    assert all([i.id == e.object_id for i, e in zip(items, expected_items)])
+
+
+def test_add_item(test_collection, test_file, mock_box_session, mock_object_id, mock_file_response):
+    expected_url = test_file.get_url()
+    mock_box_session.put.return_value = mock_file_response
+    new_file = test_collection.add_item(test_file)
+    data = json.dumps({'collections': [{'id': test_collection.object_id}]})
+    mock_box_session.put.assert_called_once_with(expected_url, data=data, headers=None, params=None)
+    assert isinstance(new_file, File)
+    assert new_file.object_id == mock_object_id
+
+
+def test_remove_item(test_collection, test_file, mock_box_session, mock_object_id, mock_file_response):
+    expected_url = test_file.get_url()
+    mock_box_session.put.return_value = mock_file_response
+    new_file = test_collection.remove_item(test_file)
+    data = json.dumps({'collections': []})
+    mock_box_session.put.assert_called_once_with(expected_url, data=data, headers=None, params=None)
+    assert isinstance(new_file, File)
+    assert new_file.object_id == mock_object_id

--- a/test/unit/object/test_item.py
+++ b/test/unit/object/test_item.py
@@ -70,6 +70,26 @@ def test_move_item(test_item_and_response, mock_box_session, test_folder, mock_o
     assert isinstance(move_response, test_item.__class__)
 
 
+def test_add_to_collection(test_item_and_response, mock_box_session, test_collection, mock_collection_id):
+    # pylint:disable=redefined-outer-name, protected-access
+    test_item, mock_item_response = test_item_and_response
+    expected_url = test_item.get_url()
+    mock_box_session.put.return_value = mock_item_response
+    add_to_collection_response = test_item.add_to_collection(test_collection)
+    mock_box_session.put.assert_called_once_with(expected_url, data=json.dumps({'collections': [{'id': mock_collection_id}]}), headers=None, params=None)
+    assert isinstance(add_to_collection_response, test_item.__class__)
+
+
+def test_remove_from_collection(test_item_and_response, mock_box_session, test_collection, mock_collection_id):
+    # pylint:disable=redefined-outer-name, protected-access
+    test_item, mock_item_response = test_item_and_response
+    expected_url = test_item.get_url()
+    mock_box_session.put.return_value = mock_item_response
+    add_to_collection_response = test_item.remove_from_collection(test_collection)
+    mock_box_session.put.assert_called_once_with(expected_url, data=json.dumps({'collections': []}), headers=None, params=None)
+    assert isinstance(add_to_collection_response, test_item.__class__)
+
+
 def test_get_shared_link(
         test_item_and_response,
         mock_box_session,


### PR DESCRIPTION
Use the Client object to get the user's collections (which just returns a list containing the singular Favorites collection). I also added a convenience method for getting favorite items directly.

Collections (i.e. just the Favorites collection) can be used to retrieve items, as well as add or remove an item from the collection. There is also `Item.add_to_collection` and `Item.remove_from_collection` which do just as they say. Note that `Item.remove_from_collection` and `Collection.remove_item` remove an item from **all collections**, since there's no way to get all of the collections an item belongs to and just remove one, as well as there's only the Favorites collection.