### PR TITLE
Add new Recents API to client

### DIFF
--- a/boxsdk/client/client.py
+++ b/boxsdk/client/client.py
@@ -318,7 +318,7 @@ class Client(Cloneable):
         )
 
     @api_call
-    def get_recent_items(self, limit=None, marker=None, fields=None):
+    def get_recent_items(self, limit=None, marker=None, fields=None, **kwargs):
         """
         Get the user's recently accessed items.
 
@@ -347,8 +347,7 @@ class Client(Cloneable):
             limit=limit,
             fields=fields,
             marker=marker,
-            return_full_pages=True,
-            supports_limit_offset_paging=False,
+            **kwargs
         )
 
     @api_call

--- a/boxsdk/client/client.py
+++ b/boxsdk/client/client.py
@@ -347,7 +347,7 @@ class Client(Cloneable):
             params['fields'] = ','.join(fields)
         box_response = self._session.get(url, params=params)
         response = box_response.json()
-        return [self.translator.translate(item['type'])(self._session, item) for item in response['entries']]
+        return [self.translator.translate(item['type'])(session=self._session, response_object=item) for item in response['entries']]
 
     @api_call
     def get_shared_item(self, shared_link, password=None):

--- a/boxsdk/client/client.py
+++ b/boxsdk/client/client.py
@@ -317,6 +317,39 @@ class Client(Cloneable):
         )
 
     @api_call
+    def get_recent_items(self, limit=100, offset=0, fields=None):
+        """
+        Get the user's recently accessed items.
+
+        :param: limit
+            The maximum number of items to return
+        :type: limit
+            `int`
+        :param offset:
+            The index at which to start returning items.
+        :type offset:
+            `int`
+        :param fields:
+            List of fields to request.
+        :type fields:
+            `Iterable` of `unicode`
+        :returns:
+            A list of the user's recently accessed items.
+        :rtype:
+            `list` of :class:`Item`
+        """
+        url = '{0}/recent_items'.format(API.BASE_API_URL)
+        params = {
+            'limit': limit,
+            'offset': offset,
+        }
+        if fields:
+            params['fields'] = ','.join(fields)
+        box_response = self._session.get(url, params=params)
+        response = box_response.json()
+        return [self.translator.translate(item['type'])(self._session, item) for item in response['entries']]
+
+    @api_call
     def get_shared_item(self, shared_link, password=None):
         """
         Get information about a Box shared link. https://box-content.readme.io/reference#get-a-shared-item

--- a/boxsdk/client/client.py
+++ b/boxsdk/client/client.py
@@ -318,7 +318,7 @@ class Client(Cloneable):
         )
 
     @api_call
-    def get_recent_items(self, limit=None, marker=None, fields=None, **kwargs):
+    def get_recent_items(self, limit=None, marker=None, fields=None, **collection_kwargs):
         """
         Get the user's recently accessed items.
 
@@ -336,6 +336,10 @@ class Client(Cloneable):
             List of fields to request on the file or folder which the `RecentItem` references.
         :type fields:
             `Iterable` of `unicode`
+        :param **collection_kwargs:
+            Keyword arguments passed to `MarkerBasedObjectCollection`.
+        :type **collection_args:
+            `dict`
         :returns:
             An iterator on the user's recent items
         :rtype:
@@ -347,7 +351,7 @@ class Client(Cloneable):
             limit=limit,
             fields=fields,
             marker=marker,
-            **kwargs
+            **collection_kwargs
         )
 
     @api_call

--- a/boxsdk/object/__init__.py
+++ b/boxsdk/object/__init__.py
@@ -5,4 +5,4 @@ from __future__ import unicode_literals
 from six.moves import map   # pylint:disable=redefined-builtin
 
 
-__all__ = list(map(str, ['collaboration', 'events', 'event', 'file', 'folder', 'group', 'group_membership', 'search', 'user']))
+__all__ = list(map(str, ['collaboration', 'events', 'event', 'file', 'folder', 'group', 'group_membership', 'recent_item', 'search', 'user']))

--- a/boxsdk/object/recent_item.py
+++ b/boxsdk/object/recent_item.py
@@ -1,0 +1,44 @@
+# coding: utf-8
+
+from __future__ import unicode_literals, absolute_import
+
+from .base_api_json_object import BaseAPIJSONObject
+
+
+class RecentItem(BaseAPIJSONObject):
+    """Represents a single recent item accessed by a Box user."""
+
+    _item_type = 'recent_item'
+
+    def __init__(self, session, response_object=None):
+        """
+        :param session:
+            The Box session used to make requests.
+        :type session:
+            :class:`BoxSession`
+        :param response_object:
+            A JSON object representing the object returned from a Box API request.
+        :type response_object:
+            `dict`
+        """
+        super(RecentItem, self).__init__(response_object=response_object)
+        self._session = session
+
+    @property
+    def translator(self):
+        """The translator used for translating Box API JSON responses into `BaseAPIJSONObject` smart objects.
+
+        :rtype:   :class:`Translator`
+        """
+        return self._session.translator
+
+    @property
+    def item(self):
+        """
+        Returns the Box Item which this recent item references.
+
+        :rtype:
+            :class:`Item`
+        """
+        item = self.response_object['item']
+        return self.translator.translate(item['type'])(self._session, item['id'], item)

--- a/boxsdk/object/recent_item.py
+++ b/boxsdk/object/recent_item.py
@@ -11,7 +11,7 @@ class RecentItem(BaseEndpoint, BaseAPIJSONObject):
 
     _item_type = 'recent_item'
 
-    def __init__(self, session, response_object=None):
+    def __init__(self, session, response_object=None, **kwargs):
         """
         :param session:
             The Box session used to make requests.

--- a/boxsdk/object/recent_item.py
+++ b/boxsdk/object/recent_item.py
@@ -11,19 +11,6 @@ class RecentItem(BaseEndpoint, BaseAPIJSONObject):
 
     _item_type = 'recent_item'
 
-    def __init__(self, session, response_object=None, **kwargs):
-        """
-        :param session:
-            The Box session used to make requests.
-        :type session:
-            :class:`BoxSession`
-        :param response_object:
-            A JSON object representing the object returned from a Box API request.
-        :type response_object:
-            `dict`
-        """
-        super(RecentItem, self).__init__(session=session, response_object=response_object)
-
     @property
     def item(self):
         """
@@ -38,8 +25,3 @@ class RecentItem(BaseEndpoint, BaseAPIJSONObject):
             object_id=item['id'],
             response_object=item,
         )
-
-    def get_url(self, *args):
-        """Base class override."""
-        # pylint:disable=arguments-differ
-        return super(RecentItem, self).get_url('recent_items', *args)

--- a/boxsdk/object/recent_item.py
+++ b/boxsdk/object/recent_item.py
@@ -2,10 +2,11 @@
 
 from __future__ import unicode_literals, absolute_import
 
+from .base_endpoint import BaseEndpoint
 from .base_api_json_object import BaseAPIJSONObject
 
 
-class RecentItem(BaseAPIJSONObject):
+class RecentItem(BaseEndpoint, BaseAPIJSONObject):
     """Represents a single recent item accessed by a Box user."""
 
     _item_type = 'recent_item'
@@ -21,16 +22,7 @@ class RecentItem(BaseAPIJSONObject):
         :type response_object:
             `dict`
         """
-        super(RecentItem, self).__init__(response_object=response_object)
-        self._session = session
-
-    @property
-    def translator(self):
-        """The translator used for translating Box API JSON responses into `BaseAPIJSONObject` smart objects.
-
-        :rtype:   :class:`Translator`
-        """
-        return self._session.translator
+        super(RecentItem, self).__init__(session=session, response_object=response_object)
 
     @property
     def item(self):
@@ -40,5 +32,14 @@ class RecentItem(BaseAPIJSONObject):
         :rtype:
             :class:`Item`
         """
-        item = self.response_object['item']
-        return self.translator.translate(item['type'])(self._session, item['id'], item)
+        item = self._response_object['item']
+        return self.translator.translate(item['type'])(
+            session=self._session,
+            object_id=item['id'],
+            response_object=item,
+        )
+
+    def get_url(self, *args):
+        """Base class override."""
+        # pylint:disable=arguments-differ
+        return super(RecentItem, self).get_url('recent_items', *args)

--- a/boxsdk/pagination/page.py
+++ b/boxsdk/pagination/page.py
@@ -5,6 +5,9 @@ from __future__ import unicode_literals, absolute_import
 from collections import Sequence
 import copy
 
+from boxsdk.object.base_object import BaseObject
+from boxsdk.object.base_endpoint import BaseEndpoint
+
 
 class Page(Sequence, object):
     """
@@ -59,11 +62,13 @@ class Page(Sequence, object):
         """
         item_json = self._response_object[self._item_entries_key_name][key]
         item_class = self._translator.translate(item_json['type'])
-        item = item_class(
-            session=self._session,
-            object_id=item_json['id'] if 'id' in item_json else None,
-            response_object=item_json,
-        )
+        kwargs = {}
+        if issubclass(item_class, BaseObject):
+            kwargs['object_id'] = item_json['id']
+        if issubclass(item_class, BaseEndpoint):
+            kwargs['session'] = self._session
+
+        item = item_class(response_object=item_json, **kwargs)
         return item
 
     def __len__(self):

--- a/boxsdk/pagination/page.py
+++ b/boxsdk/pagination/page.py
@@ -61,7 +61,7 @@ class Page(Sequence, object):
         item_class = self._translator.translate(item_json['type'])
         item = item_class(
             session=self._session,
-            object_id=item_json['id'],
+            object_id=item_json['id'] if 'id' in item_json else None,
             response_object=item_json,
         )
         return item

--- a/test/unit/client/test_client.py
+++ b/test/unit/client/test_client.py
@@ -277,15 +277,17 @@ def test_get_recent_items_returns_the_correct_items(mock_client, mock_box_sessio
     assert recent_items[0].item.object_id == file_id
 
 
-def test_get_recent_items_sends_get_with_correct_params(mock_client, mock_box_session, recent_items_response, file_id):
+def test_get_recent_items_sends_get_with_correct_params(mock_client, mock_box_session, recent_items_response):
+    limit = 50
+    offset = 10
     fields = ['modified_at', 'name']
     expected_params = {
-        'limit': 100,
-        'offset': 0,
+        'limit': limit,
+        'offset': offset,
         'fields': ','.join(fields),
     }
     mock_box_session.get.return_value = recent_items_response
-    recent_items = mock_client.get_recent_items(fields=fields)
+    mock_client.get_recent_items(limit=limit, offset=offset, fields=fields)
     mock_box_session.get.assert_called_once_with('{0}/recent_items'.format(API.BASE_API_URL), params=expected_params)
 
 

--- a/test/unit/client/test_client.py
+++ b/test/unit/client/test_client.py
@@ -277,6 +277,18 @@ def test_get_recent_items_returns_the_correct_items(mock_client, mock_box_sessio
     assert recent_items[0].item.object_id == file_id
 
 
+def test_get_recent_items_sends_get_with_correct_params(mock_client, mock_box_session, recent_items_response, file_id):
+    fields = ['modified_at', 'name']
+    expected_params = {
+        'limit': 100,
+        'offset': 0,
+        'fields': ','.join(fields),
+    }
+    mock_box_session.get.return_value = recent_items_response
+    recent_items = mock_client.get_recent_items(fields=fields)
+    mock_box_session.get.assert_called_once_with('{0}/recent_items'.format(API.BASE_API_URL), params=expected_params)
+
+
 @pytest.mark.parametrize('password', (None, 'p4ssw0rd'))
 def test_get_shared_item_returns_the_correct_item(mock_client, mock_box_session, shared_item_response, password):
     # pylint:disable=redefined-outer-name

--- a/test/unit/client/test_client.py
+++ b/test/unit/client/test_client.py
@@ -152,13 +152,13 @@ def search_response(file_id, folder_id):
 
 
 @pytest.fixture(scope='module')
-def recent_items_response(file_id, marker_id):
+def recent_items_response(file_id):
     mock_network_response = Mock(DefaultNetworkResponse)
     mock_network_response.json.return_value = {
         'entries': [
             {'type': 'recent_item', 'item': {'type': 'file', 'id': file_id}}
         ],
-        'next_marker': marker_id,
+        'next_marker': None,
         'limit': 100,
     }
     return mock_network_response
@@ -281,14 +281,14 @@ def test_create_group_returns_the_correct_group_object(mock_client, mock_box_ses
     assert new_group.name == test_group_name
 
 
-def test_get_recent_items_returns_the_correct_items(mock_client, mock_box_session, recent_items_response, file_id, marker_id):
+def test_get_recent_items_returns_the_correct_items(mock_client, mock_box_session, recent_items_response, file_id):
     mock_box_session.get.return_value = recent_items_response
     recent_items = mock_client.get_recent_items()
     assert isinstance(recent_items, MarkerBasedObjectCollection)
-    page = recent_items.next()
-    assert page[0].item.object_id == file_id
+    recent_item = recent_items.next()
+    assert recent_item.item.object_id == file_id
     next_pointer = recent_items.next_pointer()
-    assert next_pointer == marker_id
+    assert next_pointer is None
 
 
 def test_get_recent_items_sends_get_with_correct_params(mock_client, mock_box_session, recent_items_response, marker_id):

--- a/test/unit/client/test_client.py
+++ b/test/unit/client/test_client.py
@@ -145,6 +145,15 @@ def search_response(file_id, folder_id):
     return mock_network_response
 
 
+@pytest.fixture(scope='module')
+def recent_items_response(file_id):
+    mock_network_response = Mock(DefaultNetworkResponse)
+    mock_network_response.json.return_value = {'entries': [
+        {'type': 'recent_item', 'item': {'type': 'file', 'id': file_id}}
+    ]}
+    return mock_network_response
+
+
 @pytest.mark.parametrize('test_class, factory_method_name', [
     (Folder, 'folder'),
     (File, 'file'),
@@ -260,6 +269,12 @@ def test_create_group_returns_the_correct_group_object(mock_client, mock_box_ses
     assert isinstance(new_group, Group)
     assert new_group.object_id == 1234
     assert new_group.name == test_group_name
+
+
+def test_get_recent_items_returns_the_correct_items(mock_client, mock_box_session, recent_items_response, file_id):
+    mock_box_session.get.return_value = recent_items_response
+    recent_items = mock_client.get_recent_items()
+    assert recent_items[0].item.object_id == file_id
 
 
 @pytest.mark.parametrize('password', (None, 'p4ssw0rd'))

--- a/test/unit/object/test_recent_item.py
+++ b/test/unit/object/test_recent_item.py
@@ -1,0 +1,16 @@
+# coding: utf-8
+
+from __future__ import unicode_literals
+
+from boxsdk.object.recent_item import RecentItem
+
+
+def test_init_recent_item(mock_box_session, mock_object_id):
+    recent_item = RecentItem(
+        mock_box_session,
+        {
+            "type": "recent_item",
+            "item": {"type": "file", "id": mock_object_id}
+        })
+    assert recent_item['type'] == 'recent_item'
+    assert recent_item.item.object_id == mock_object_id

--- a/test/unit/object/test_recent_item.py
+++ b/test/unit/object/test_recent_item.py
@@ -7,8 +7,8 @@ from boxsdk.object.recent_item import RecentItem
 
 def test_init_recent_item(mock_box_session, mock_object_id):
     recent_item = RecentItem(
-        mock_box_session,
-        {
+        session=mock_box_session,
+        response_object={
             "type": "recent_item",
             "item": {"type": "file", "id": mock_object_id}
         })

--- a/test/unit/object/test_recent_item.py
+++ b/test/unit/object/test_recent_item.py
@@ -14,3 +14,4 @@ def test_init_recent_item(mock_box_session, mock_object_id):
         })
     assert recent_item['type'] == 'recent_item'
     assert recent_item.item.object_id == mock_object_id
+    assert recent_item.item.session is mock_box_session


### PR DESCRIPTION
See: https://developer.box.com/v2.0/reference#recent-item-object

Use the Client to retrieve a user's recently accessed items on Box.

`RecentItem` class allows the translator to correctly instantiate the item returned by the API, which has the field `type='recent_item'`. This provides some additional fields, and access to the underlying File/Folder as the property `RecentItem.item`