### PR TITLE
Limit/Offset and Marker Based pagination

### DIFF
--- a/boxsdk/object/folder.py
+++ b/boxsdk/object/folder.py
@@ -9,6 +9,8 @@ from boxsdk.config import API
 from boxsdk.object.group import Group
 from boxsdk.object.item import Item
 from boxsdk.object.user import User
+from boxsdk.pagination.limit_offset_based_object_collection import LimitOffsetBasedObjectCollection
+from boxsdk.pagination.marker_based_object_collection import MarkerBasedObjectCollection
 from boxsdk.util.api_call_decorator import api_call
 from boxsdk.util.text_enum import TextEnum
 
@@ -153,6 +155,69 @@ class Folder(Item):
         box_response = self._session.get(url, params=params)
         response = box_response.json()
         return [self.translator.translate(item['type'])(self._session, item['id'], item) for item in response['entries']]
+
+    @api_call
+    def get_items_limit_offset(self, limit=None, offset=0, fields=None):
+        """
+        Get the items in a folder using limit-offset paging.
+
+        :param limit:
+            The maximum number of items to return per page. If not specified, then will use the server-side default.
+        :type limit:
+            `int` or None
+        :param offset:
+            The index at which to start returning items.
+        :type offset:
+            `int`
+        :param fields:
+            List of fields to request.
+        :type fields:
+            `Iterable` of `unicode`
+        :returns:
+            An iterator of the items in the folder.
+        :rtype:
+            :class:`BoxObjectCollection`
+        """
+        return LimitOffsetBasedObjectCollection(
+            self.session,
+            self.get_url('items'),
+            limit=limit,
+            fields=fields,
+            offset=offset,
+            return_full_pages=False,
+        )
+
+    @api_call
+    def get_items_marker(self, limit=None, marker=None, fields=None):
+        """
+        Get the items in a folder using marker-based paging.
+
+        :param limit:
+            The maximum number of items to return per page. If not specified, then will use the server-side default.
+        :type limit:
+            `int` or None
+        :param marker:
+            The offset index to start paging from.
+        :type marker:
+            `str` or None
+        :param fields:
+            List of fields to request.
+        :type fields:
+            `Iterable` of `unicode`
+        :returns:
+            An iterator of the items in the folder.
+        :rtype:
+            :class:`BoxObjectCollection`
+        """
+        return MarkerBasedObjectCollection(
+            self.session,
+            self.get_url('items'),
+            limit=limit,
+            fields=fields,
+            marker=marker,
+            return_full_pages=False,
+            supports_limit_offset_paging=True,
+        )
 
     @api_call
     def upload_stream(

--- a/boxsdk/pagination/__init__.py
+++ b/boxsdk/pagination/__init__.py
@@ -1,0 +1,3 @@
+# coding: utf-8
+
+from __future__ import unicode_literals

--- a/boxsdk/pagination/box_object_collection.py
+++ b/boxsdk/pagination/box_object_collection.py
@@ -1,0 +1,194 @@
+# coding: utf-8
+
+from __future__ import unicode_literals
+
+from abc import ABCMeta, abstractmethod
+import collections
+
+from six import add_metaclass
+
+from boxsdk.pagination.page import Page
+
+
+@add_metaclass(ABCMeta)
+class BoxObjectCollection(collections.Iterator, object):
+    """
+    An iterator that represents a collection of Box objects (BaseObject).
+
+    A BoxObjectCollection instance contains everything it needs in order to retrieve and page through
+    responses from Box API endpoints that return collections of Box objects.
+
+    This class only has two public methods:
+
+    1). next(), which returns either a Page (sequence of BaseObjects) or individual BaseObjects based on
+    the constructor argument 'return_full_pages'.
+
+    2). next_pointer(), which returns the pointer (either an offset or a marker, based on the endpoint) that
+    will be used to retrieve the next page of Box objects. This pointer can be used when requesting new
+    BoxObjectCollection instances that start off from a particular page, instead of from the very beginning.
+    """
+    def __init__(
+            self,
+            session,
+            url,
+            limit=None,
+            fields=None,
+            additional_params=None,
+            return_full_pages=False,
+    ):
+        """
+        :param session:
+            The Box session used to make requests.
+        :type session:
+            :class:`BoxSession`
+        :param url:
+            The endpoint url to hit.
+        :type url:
+            `unicode`
+        :param limit:
+            The number of entries for each page to return. The default, as well as the upper limit of this value,
+            differs by endpoint. See https://developer.box.com/reference. If limit is set to None, then the default
+            limit (returned by Box in the response) is used.
+        :type limit:
+            `int` or None
+        :param fields:
+            List of fields to request. If None, will return the default fields for the object.
+        :type fields:
+            `Iterable` of `unicode` or None
+        :param additional_params:
+            Additional HTTP params to send in the request.
+        :type additional_params:
+            `dict` or None
+        :param return_full_pages:
+            If True, then the returned iterator for this collection will return full pages of Box objects on each
+            call to next(). If False, the iterator will return a single Box object on each next() call.
+        :type return_full_pages:
+            `bool`
+        """
+        super(BoxObjectCollection, self).__init__()
+        self._session = session
+        self._url = url
+        self._limit = limit
+        self._fields = fields
+        self._additional_params = additional_params
+        self._return_full_pages = return_full_pages
+        self._has_retrieved_all_items = False
+        self._all_items = None
+
+    def next(self):
+        """
+        Returns either a Page (a Sequence of BaseObjects) or a BaseObject depending on self._return_full_pages.
+
+        Invoking this method may make an API call to Box. Any exceptions that can occur while making requests
+        may be raised in this method.
+
+        :rtype:
+            :class:`Page` or :class:`BaseObject`
+        """
+        if self._all_items is None:
+            self._all_items = self._items_generator()
+        return next(self._all_items)
+
+    __next__ = next
+
+    def _items_generator(self):
+        """
+        :rtype:
+            :class:`Page` or :class:`BaseObject`
+        """
+        while not self._has_retrieved_all_items:
+            response_object = self._load_next_page()
+
+            # If the limit was not specified, then it should default to whatever the server tells us.
+            if self._limit is None:
+                self._limit = response_object['limit']
+
+            self._update_pointer_to_next_page(response_object)
+            self._has_retrieved_all_items = not self._has_more_pages(response_object)
+            page = Page(self._session, response_object)
+
+            if self._return_full_pages:
+                yield page
+            else:
+                # It's possible for the Box API to return 0 items in a page, even if there are more items to be
+                # retrieved on subsequent pages. When self._return_full_pages is True, then yielding a 0-item
+                # page is fine because that's what the page returned.
+                # But when we are iterating over individual items, and not pages, it's odd to yield a sequence of
+                # Nones (for that page that had 0 items). So instead, we continue to request more pages until we
+                # have Box objects to yield.
+                if not page:
+                    continue
+                for entry in page:
+                    yield entry
+
+    def _load_next_page(self):
+        """
+        Request the next page of entries from Box. Raises any network-related exceptions, including BoxAPIException.
+        Returns a parsed dictionary of the JSON response from Box
+
+        :rtype:
+            `dict`
+        """
+        params = {}
+        if self._limit is not None:
+            params['limit'] = self._limit
+        if self._fields:
+            params['fields'] = ','.join(self._fields)
+        if self._additional_params:
+            params.update(self._additional_params)
+        params.update(self._next_page_pointer_params())
+        box_response = self._session.get(self._url, params=params)
+        return box_response.json()
+
+    @abstractmethod
+    def _update_pointer_to_next_page(self, response_object):
+        """
+        Update the internal pointer attribute of this class to what will be used to request the next page
+        of Box objects.
+
+        A "pointer" can either be a marker (for marker-based paging) or an offset (for limit-offset paging).
+
+        :param response_object:
+            The parsed HTTP response from Box after requesting more pages.
+        :type response_object:
+            `dict`
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def _has_more_pages(self, response_object):
+        """
+        Are there more pages of entries to query Box for? This gets invoked after self._update_pointer_to_next_page().
+
+        :param response_object:
+            The parsed HTTP response from Box after requesting more pages.
+        :type response_object:
+            `dict`
+        :rtype:
+            `bool`
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def _next_page_pointer_params(self):
+        """
+        The dict of HTTP params that specify which page of Box objects to retrieve.
+
+        :rtype:
+            `dict`
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def next_pointer(self):
+        """
+        The pointer that will be used to request the next page of Box objects.
+
+        For limit-offset based paging, this is an offset. For marker-based paging, this is a marker.
+
+        The pointer only gets progressed upon successful page requests to Box.
+
+        :rtype:
+            varies
+        """
+        raise NotImplementedError

--- a/boxsdk/pagination/limit_offset_based_object_collection.py
+++ b/boxsdk/pagination/limit_offset_based_object_collection.py
@@ -1,0 +1,83 @@
+# coding: utf-8
+
+from __future__ import unicode_literals
+
+from .box_object_collection import BoxObjectCollection
+
+
+class LimitOffsetBasedObjectCollection(BoxObjectCollection):
+    """
+    An iterator of Box objects (BaseObjects) that were retrieved from a Box API endpoint that supports
+    limit-offset type of pagination.
+
+    See https://developer.box.com/reference#pagination for more details.
+    """
+
+    def __init__(
+            self,
+            session,
+            url,
+            limit=None,
+            fields=None,
+            additional_params=None,
+            return_full_pages=False,
+            offset=0,
+    ):
+        """
+        :param offset:
+            The offset index to start paging from.
+        :type offset:
+            `int`
+        """
+        super(LimitOffsetBasedObjectCollection, self).__init__(
+            session,
+            url,
+            limit=limit,
+            fields=fields,
+            additional_params=additional_params,
+            return_full_pages=return_full_pages,
+        )
+        self._offset = offset
+
+    def _update_pointer_to_next_page(self, response_object):
+        """Baseclass override."""
+        total_count = response_object['total_count']
+
+        # The API might use a lower limit than the client asked for, if the
+        # client asked for a limit above the maximum limit for that endpoint.
+        # The API is supposed to respond with the limit that it actually used.
+        # If that is given, then use that limit for the offset calculation, and
+        # also for the remainder of the paging.
+        #
+        # Similarly, the API reports the offset that it used. In theory, this
+        # should always be the same as what was requested. But just in case, do
+        # the same thing with offset.
+        if 'limit' in response_object:
+            self._limit, old_limit = int(response_object['limit']), self._limit
+
+            # If the API erroneously sends a bad value for limit, we want to
+            # avoid getting into an infinite chain of API calls. So abort with
+            # a runtime error.
+            if self._limit <= 0 < old_limit:
+                self._offset = total_count  # Disable additional paging.
+                raise RuntimeError('API returned limit={0}, cannot continue paging'.format(self._limit))
+
+        if 'offset' in response_object:
+            self._offset = int(response_object['offset'])
+
+        if total_count >= self._offset + self._limit:
+            self._offset += self._limit
+        else:
+            self._offset = total_count
+
+    def _has_more_pages(self, response_object):
+        """Baseclass override."""
+        return self._offset < response_object['total_count']
+
+    def _next_page_pointer_params(self):
+        """Baseclass override."""
+        return {'offset': self._offset}
+
+    def next_pointer(self):
+        """Baseclass override."""
+        return self._offset

--- a/boxsdk/pagination/marker_based_object_collection.py
+++ b/boxsdk/pagination/marker_based_object_collection.py
@@ -1,0 +1,87 @@
+# coding: utf-8
+
+from __future__ import unicode_literals
+
+from .box_object_collection import BoxObjectCollection
+
+
+class MarkerBasedObjectCollection(BoxObjectCollection):
+    """
+    An iterator of Box objects (BaseObjects) that were retrieved from a Box API endpoint that supports
+    marker type of pagination.
+
+    See https://developer.box.com/reference#pagination for more details.
+    """
+
+    def __init__(
+            self,
+            session,
+            url,
+            limit=None,
+            fields=None,
+            additional_params=None,
+            return_full_pages=False,
+            marker=None,
+            supports_limit_offset_paging=False,
+    ):
+        """
+        :param marker:
+            The offset index to start paging from.
+        :type marker:
+            `str` or None
+        :param supports_limit_offset_paging:
+            Does this particular endpoint also support limit-offset paging? This information is needed, as
+            the endpoints that support both require an special extra request parameter.
+        :type supports_limit_offset_paging:
+            `bool`
+        """
+        super(MarkerBasedObjectCollection, self).__init__(
+            session,
+            url,
+            limit=limit,
+            fields=fields,
+            additional_params=additional_params,
+            return_full_pages=return_full_pages,
+        )
+        self._marker = marker
+        self._supports_limit_offset_paging = supports_limit_offset_paging
+
+    def _update_pointer_to_next_page(self, response_object):
+        """Baseclass override."""
+        self._marker = self._get_next_marker_from_response_object(response_object)
+
+    def _has_more_pages(self, response_object):
+        """Baseclass override."""
+        return bool(self._get_next_marker_from_response_object(response_object))
+
+    @staticmethod
+    def _get_next_marker_from_response_object(response_object):
+        """Get the marker that should be used to retrieve the next page.
+
+        When we've just retrieved the last page, the API is inconsistent about
+        what it returns. Some endpoints return "next_marker":"", some return
+        "next_marker":null, some don't give any "next_marker" value. In all of
+        these cases, this method will return `None`.
+
+        Otherwise, this method returns the string value of the "next_marker"
+        field.
+
+        :rtype:
+            `unicode` or `None`
+        """
+        return response_object.get('next_marker') or None
+
+    def _next_page_pointer_params(self):
+        """Baseclass override."""
+        pointer_params = {}
+        # For transitioning endpoints that support both marker and limit-offset paging, we must specify an
+        # additional 'useMarker' parameter to the Box API.
+        if self._supports_limit_offset_paging:
+            pointer_params['useMarker'] = True
+        if self._marker is not None:
+            pointer_params['marker'] = self._marker
+        return pointer_params
+
+    def next_pointer(self):
+        """Baseclass override."""
+        return self._marker

--- a/boxsdk/pagination/page.py
+++ b/boxsdk/pagination/page.py
@@ -1,0 +1,76 @@
+# coding: utf-8
+
+from __future__ import unicode_literals, absolute_import
+
+from collections import Sequence
+import copy
+
+
+class Page(Sequence, object):
+    """
+    A sequence of BaseObjects that belong to a page returned from a paging api call.
+
+    The Page makes available detailed response data for page requests.
+    """
+    _item_entries_key_name = "entries"
+
+    def __init__(self, session, response_object):
+        """
+        :param session:
+            The Box session used to make the request that generated the response.
+        :type session:
+            :class:`BoxSession`
+        :param response_object:
+            The parsed HTTP response from Box after requesting more pages.
+        :type response_object:
+            `dict`
+        """
+        super(Page, self).__init__()
+        self._session = session
+        self._response_object = response_object
+
+    @property
+    def _translator(self):
+        """The translator used for translating Box API JSON responses into `BaseAPIJSONObject` smart objects.
+
+        :rtype:   :class:`Translator`
+        """
+        return self._session.translator
+
+    @property
+    def response_object(self):
+        """
+        Return a copy of the response object for this Page.
+
+        :rtype: `dict`
+        """
+        return copy.deepcopy(self._response_object)
+
+    def __getitem__(self, key):
+        """
+        Try to get the attribute from the API response object.
+
+        :param key:
+            The attribute to retrieve from the API response object.
+        :type key:
+            `unicode`
+        :rtype:
+            :class:`BaseObject`
+        """
+        item_json = self._response_object[self._item_entries_key_name][key]
+        item_class = self._translator.translate(item_json['type'])
+        item = item_class(
+            session=self._session,
+            object_id=item_json['id'],
+            response_object=item_json,
+        )
+        return item
+
+    def __len__(self):
+        """
+        Get the number of items in the page.
+
+        :rtype:
+            `int`
+        """
+        return len(self._response_object[self._item_entries_key_name])

--- a/test/unit/object/test_folder.py
+++ b/test/unit/object/test_folder.py
@@ -13,6 +13,8 @@ from boxsdk.network.default_network import DefaultNetworkResponse
 from boxsdk.object.file import File
 from boxsdk.object.collaboration import Collaboration, CollaborationRole
 from boxsdk.object.folder import Folder, FolderSyncState
+from boxsdk.pagination.limit_offset_based_object_collection import LimitOffsetBasedObjectCollection
+from boxsdk.pagination.marker_based_object_collection import MarkerBasedObjectCollection
 from boxsdk.session.box_session import BoxResponse
 
 
@@ -137,6 +139,16 @@ def test_get_items(test_folder, mock_box_session, mock_items_response, limit, of
     mock_box_session.get.assert_called_once_with(expected_url, params=expected_params)
     assert items == expected_items
     assert all([i.id == e.object_id for i, e in zip(items, expected_items)])
+
+
+def test_get_items_marker_returns_marker_instance(test_folder):
+    limit_offset_object_collection = test_folder.get_items_limit_offset()
+    assert isinstance(limit_offset_object_collection, LimitOffsetBasedObjectCollection)
+
+
+def test_get_items_limit_offset_returns_limit_offset_instance(test_folder):
+    marker_object_collection = test_folder.get_items_marker()
+    assert isinstance(marker_object_collection, MarkerBasedObjectCollection)
 
 
 @pytest.mark.parametrize('is_stream', (True, False))

--- a/test/unit/pagination/__init__.py
+++ b/test/unit/pagination/__init__.py
@@ -1,0 +1,3 @@
+# coding: utf-8
+
+from __future__ import unicode_literals

--- a/test/unit/pagination/box_object_collection_test_base.py
+++ b/test/unit/pagination/box_object_collection_test_base.py
@@ -13,8 +13,9 @@ from boxsdk.util.translator import Translator
 class BoxObjectCollectionTestBase(object):
     NUM_ENTRIES = 25
 
+    @staticmethod
     @pytest.fixture()
-    def translator(self):
+    def translator():
         return Translator()
 
     @pytest.fixture()
@@ -51,7 +52,8 @@ class BoxObjectCollectionTestBase(object):
         """
         raise NotImplementedError
 
-    def _assert_items_dict_and_objects_same(self, expected_items_dict, returned_item_objects):
+    @staticmethod
+    def _assert_items_dict_and_objects_same(expected_items_dict, returned_item_objects):
         """
         A fixture very specific to this test class. Asserts that the list of items in dictionary form are the
         same (at least in name, and in quantity) as a list of BaseObjects.

--- a/test/unit/pagination/box_object_collection_test_base.py
+++ b/test/unit/pagination/box_object_collection_test_base.py
@@ -1,0 +1,109 @@
+# coding: utf-8
+
+from __future__ import unicode_literals, absolute_import
+from abc import ABCMeta, abstractmethod
+from six import add_metaclass
+from six.moves import range   # pylint:disable=redefined-builtin
+import pytest
+
+from boxsdk.util.translator import Translator
+
+
+@add_metaclass(ABCMeta)
+class BoxObjectCollectionTestBase(object):
+    NUM_ENTRIES = 25
+
+    @pytest.fixture()
+    def translator(self):
+        return Translator()
+
+    @pytest.fixture()
+    def entries(self):
+        all_entries = []
+        for i in range(self.NUM_ENTRIES):
+            all_entries.append({
+                "type": "file",
+                "id": str(1000 + i),
+                "sequence_id": str(i),
+                "etag": str(10 + i),
+                "name": "file_{0}.txt".format(i),
+            })
+        return all_entries
+
+    @abstractmethod
+    @pytest.fixture()
+    def mock_items_response(self, entries):
+        raise NotImplementedError
+
+    @abstractmethod
+    @pytest.fixture()
+    def mock_session(self, translator, mock_items_response):
+        raise NotImplementedError
+
+    @abstractmethod
+    def _object_collection_instance(self, session, limit, return_full_pages=False, starting_pointer=None):
+        """
+        :type session: :class:`BoxSession`
+        :type limit: `int`
+        :type return_full_pages: `bool`
+        :type starting_pointer: varies
+        :rtype: :class:`BoxObjectCollection`
+        """
+        raise NotImplementedError
+
+    def _assert_items_dict_and_objects_same(self, expected_items_dict, returned_item_objects):
+        """
+        A fixture very specific to this test class. Asserts that the list of items in dictionary form are the
+        same (at least in name, and in quantity) as a list of BaseObjects.
+
+        :param expected_items_dict: List of expected items, represented as a dictionary.
+        :type expected_items_dict: `list` of `dict`
+        :param returned_item_objects: List of item instances (BaseObject) returned by SUT.
+        :type returned_item_objects: `list` of class:`BaseObject`
+        """
+        expected_num = len(expected_items_dict)
+        actual_num = len(returned_item_objects)
+        assert actual_num == expected_num, 'Expected {0} items, got {1}'.format(expected_num, actual_num)
+        returned_item_names = [item.name for item in returned_item_objects]
+        for expected_item_dict in expected_items_dict:
+            assert expected_item_dict['name'] in returned_item_names, 'Missing item: {0}'.format(expected_item_dict['name'])
+
+    @pytest.mark.parametrize('return_full_pages', (True, False))
+    @pytest.mark.parametrize('limit', (1, 3, 5, NUM_ENTRIES, 1000))
+    def test_object_collection_pages_through_all_entries(self, mock_session, entries, limit, return_full_pages):
+        """
+        Tests the basic iteration functionality of the box object collection.
+        """
+        object_collection = self._object_collection_instance(mock_session, limit, return_full_pages)
+        iterated_items = []
+        for item_or_page in object_collection:
+            if return_full_pages:
+                iterated_items.extend(item_or_page)
+            else:
+                iterated_items.append(item_or_page)
+        self._assert_items_dict_and_objects_same(entries, iterated_items)
+
+    def test_new_object_collection_starts_off_from_last_pointer(self, mock_session, entries):
+        """
+        Start paging with one object collection instance, and then finish paging with a new object collection
+        instance, starting off from the next_pointer() of the previous instance.
+
+        The iterated items should be identical as if it were iterated through with just one object collection
+        instance.
+        """
+        iterated_items = []
+        object_collection = self._object_collection_instance(mock_session, limit=5, return_full_pages=True)
+        iterated_items.extend(object_collection.next())
+        next_pointer = object_collection.next_pointer()
+
+        # Create a new object collection, starting off where the previous collection left off.
+        new_object_collection = self._object_collection_instance(
+            mock_session,
+            limit=5,
+            return_full_pages=True,
+            starting_pointer=next_pointer
+        )
+        for page in new_object_collection:
+            iterated_items.extend(page)
+
+        self._assert_items_dict_and_objects_same(entries, iterated_items)

--- a/test/unit/pagination/test_limit_offset_based_object_collection.py
+++ b/test/unit/pagination/test_limit_offset_based_object_collection.py
@@ -1,0 +1,106 @@
+# coding: utf-8
+
+from __future__ import unicode_literals, absolute_import
+import json
+from mock import Mock, PropertyMock
+import pytest
+
+from boxsdk.network.default_network import DefaultNetworkResponse
+from boxsdk.pagination.limit_offset_based_object_collection import LimitOffsetBasedObjectCollection
+from boxsdk.session.box_session import BoxResponse, BoxSession
+from .box_object_collection_test_base import BoxObjectCollectionTestBase
+
+
+class TestLimitOffsetBasedObjectCollection(BoxObjectCollectionTestBase):
+    DEFAULT_LIMIT = 100
+
+    @pytest.fixture()
+    def mock_items_response(self, entries):
+        """Baseclass override."""
+        # pylint:disable=redefined-outer-name
+        def get_response(limit, offset):
+            mock_box_response = Mock(BoxResponse)
+            mock_network_response = Mock(DefaultNetworkResponse)
+            mock_box_response.network_response = mock_network_response
+            mock_box_response.json.return_value = mock_json = {
+                'entries': entries[offset:limit + offset],
+                'total_count': len(entries),
+                'limit': limit,
+            }
+            mock_box_response.content = json.dumps(mock_json).encode()
+            mock_box_response.status_code = 200
+            mock_box_response.ok = True
+            return mock_box_response
+        return get_response
+
+    @pytest.fixture()
+    def mock_session(self, translator, mock_items_response):
+        """Baseclass override."""
+        mock_box_session = Mock(BoxSession)
+        type(mock_box_session).translator = PropertyMock(
+            return_value=translator
+        )
+
+        def mock_items_side_effect(_, params):
+            limit = min(params.get('limit', self.DEFAULT_LIMIT), self.DEFAULT_LIMIT)
+            offset = params.get('offset', 0)
+            return mock_items_response(limit, offset)
+
+        mock_box_session.get.side_effect = mock_items_side_effect
+        return mock_box_session
+
+    def _object_collection_instance(self, session, limit=None, return_full_pages=False, starting_pointer=None):
+        """Baseclass override."""
+        if starting_pointer is None:
+            starting_pointer = 0
+        return LimitOffsetBasedObjectCollection(
+            session,
+            '/some/endpoint',
+            limit=limit,
+            return_full_pages=return_full_pages,
+            offset=starting_pointer,
+        )
+
+    @pytest.mark.parametrize('return_full_pages', (True, False))
+    def test_object_collection_sets_next_pointer_correctly(self, mock_session, return_full_pages):
+        page_size = 10
+        object_collection = LimitOffsetBasedObjectCollection(
+            mock_session,
+            '/some/endpoint',
+            limit=page_size,
+            return_full_pages=return_full_pages,
+        )
+
+        assert object_collection.next_pointer() == 0
+        object_collection.next()
+        assert object_collection.next_pointer() == page_size
+
+        # Iterate to the last page, which doesn't return a full page.
+        [_ for _ in object_collection]  # pylint:disable=pointless-statement
+        assert object_collection.next_pointer() == self.NUM_ENTRIES
+
+    def test_object_collection_raises_stop_iteration_when_starting_offset_is_too_far(self, mock_session, entries):
+        """
+        If the specified initial offset for the object collection is higher than the total number of items,
+        then the first call to next() on the object collection should raise a StopIteration.
+        """
+        starting_offset = len(entries) + 10
+        object_collection = self._object_collection_instance(
+            mock_session,
+            limit=5,
+            return_full_pages=False,
+            starting_pointer=starting_offset
+        )
+        with pytest.raises(StopIteration):
+            object_collection.next()
+
+    def test_object_collection_sets_limit_to_returned_value_if_originally_none(self, mock_session):
+        # No limit specified
+        object_collection = self._object_collection_instance(mock_session)
+        object_collection.next()
+        assert object_collection._limit == self.DEFAULT_LIMIT   # pylint:disable=protected-access
+
+    def test_object_collection_sets_limit_to_returned_value_if_originally_too_high(self, mock_session):
+        object_collection = self._object_collection_instance(mock_session, limit=(1 + self.DEFAULT_LIMIT))
+        object_collection.next()
+        assert object_collection._limit == self.DEFAULT_LIMIT   # pylint:disable=protected-access

--- a/test/unit/pagination/test_marker_based_object_collection.py
+++ b/test/unit/pagination/test_marker_based_object_collection.py
@@ -20,14 +20,15 @@ class TestMarkerBasedObjectCollection(BoxObjectCollectionTestBase):
 
     NO_NEXT_MARKER = object()
 
+    @staticmethod
     @pytest.fixture(params=['', None, NO_NEXT_MARKER])
-    def next_marker_value_for_last_page(self, request):
+    def next_marker_value_for_last_page(request):
         return request.param
 
     @pytest.fixture()
     def mock_items_response(self, entries, next_marker_value_for_last_page):
         """Baseclass override."""
-        # pylint:disable=redefined-outer-name
+        # pylint:disable=redefined-outer-name,arguments-differ
         def get_response(limit, marker):
             mock_box_response = Mock(BoxResponse)
             mock_network_response = Mock(DefaultNetworkResponse)

--- a/test/unit/pagination/test_marker_based_object_collection.py
+++ b/test/unit/pagination/test_marker_based_object_collection.py
@@ -1,0 +1,109 @@
+# coding: utf-8
+
+from __future__ import unicode_literals, absolute_import
+import json
+from mock import Mock, PropertyMock, ANY
+import pytest
+
+from boxsdk.network.default_network import DefaultNetworkResponse
+from boxsdk.pagination.marker_based_object_collection import MarkerBasedObjectCollection
+from boxsdk.session.box_session import BoxResponse, BoxSession
+from .box_object_collection_test_base import BoxObjectCollectionTestBase
+
+
+class TestMarkerBasedObjectCollection(BoxObjectCollectionTestBase):
+    """
+    In order to conveniently mimic marker based paging for the purposes of this test, the markers ('next_marker' in
+    the response) returned by the mock_session object is always going to be of the convention: "marker_i", where
+    i is the starting 0-index based offset of the element.
+    """
+
+    NO_NEXT_MARKER = object()
+
+    @pytest.fixture(params=['', None, NO_NEXT_MARKER])
+    def next_marker_value_for_last_page(self, request):
+        return request.param
+
+    @pytest.fixture()
+    def mock_items_response(self, entries, next_marker_value_for_last_page):
+        """Baseclass override."""
+        # pylint:disable=redefined-outer-name
+        def get_response(limit, marker):
+            mock_box_response = Mock(BoxResponse)
+            mock_network_response = Mock(DefaultNetworkResponse)
+            mock_box_response.network_response = mock_network_response
+
+            mock_json = {}
+            # The marker string should be of format: "marker_i", where i is the offset. Parse that out.
+            # If the marker is None, then begin paging from the start of the entries.
+            offset = 0
+            if marker is not None:
+                offset = int(marker.split('_')[1])
+            mock_json['entries'] = entries[offset:limit + offset]
+
+            # A next_marker is only returned if there are more pages left.
+            if (offset + limit) < len(entries):
+                mock_json['next_marker'] = 'marker_{0}'.format(offset + limit)
+            elif next_marker_value_for_last_page is not self.NO_NEXT_MARKER:
+                mock_json['next_marker'] = next_marker_value_for_last_page
+
+            mock_box_response.json.return_value = mock_json
+            mock_box_response.content = json.dumps(mock_json).encode()
+            mock_box_response.status_code = 200
+            mock_box_response.ok = True
+            return mock_box_response
+        return get_response
+
+    @pytest.fixture()
+    def mock_session(self, translator, mock_items_response):
+        """Baseclass override."""
+        mock_box_session = Mock(BoxSession)
+        type(mock_box_session).translator = PropertyMock(return_value=translator)
+
+        def mock_items_side_effect(_, params):
+            limit = params['limit']
+            marker = params.get('marker', None)
+            return mock_items_response(limit, marker)
+
+        mock_box_session.get.side_effect = mock_items_side_effect
+        return mock_box_session
+
+    def _object_collection_instance(  # pylint:disable=arguments-differ
+            self,
+            session,
+            limit,
+            return_full_pages=False,
+            starting_pointer=None,
+            supports_limit_offset_paging=False
+    ):
+        """Baseclass override."""
+        return MarkerBasedObjectCollection(
+            session,
+            '/some/endpoint',
+            limit=limit,
+            return_full_pages=return_full_pages,
+            marker=starting_pointer,
+            supports_limit_offset_paging=supports_limit_offset_paging,
+        )
+
+    @pytest.mark.parametrize('return_full_pages', (True, False))
+    def test_object_collection_sets_next_pointer_correctly(self, mock_session, return_full_pages):
+        object_collection = self._object_collection_instance(mock_session, limit=5, return_full_pages=return_full_pages)
+        assert object_collection.next_pointer() is None
+        object_collection.next()
+        assert object_collection.next_pointer() == 'marker_5'
+
+    @pytest.mark.parametrize('supports_limit_offset_paging', (True, False))
+    def test_object_collection_specifies_marker_param(self, mock_session, supports_limit_offset_paging):
+        object_collection = self._object_collection_instance(
+            mock_session,
+            limit=100,
+            supports_limit_offset_paging=supports_limit_offset_paging
+        )
+        object_collection.next()
+
+        # Assert
+        expected_params = {'limit': 100}
+        if supports_limit_offset_paging:
+            expected_params['useMarker'] = True
+        mock_session.get.assert_called_with(ANY, params=expected_params)

--- a/test/unit/pagination/test_page.py
+++ b/test/unit/pagination/test_page.py
@@ -1,0 +1,107 @@
+# coding: utf-8
+
+from __future__ import unicode_literals, absolute_import
+
+from mock import Mock, PropertyMock
+import pytest
+from six.moves import range  # pylint:disable=redefined-builtin
+
+from boxsdk.object.file import File
+from boxsdk.object.folder import Folder
+from boxsdk.pagination.page import Page
+from boxsdk.session.box_session import BoxSession
+from boxsdk.util.translator import Translator
+
+
+@pytest.fixture()
+def translator():
+    return Translator()
+
+
+@pytest.fixture()
+def mock_session(translator):
+    mock_box_session = Mock(BoxSession)
+    type(mock_box_session).translator = PropertyMock(
+        return_value=translator
+    )
+    return mock_box_session
+
+
+@pytest.fixture()
+def page_builder(mock_session):
+    def factory_function(response):
+        return Page(
+            session=mock_session,
+            response_object=response
+        )
+    return factory_function
+
+
+@pytest.fixture()
+def item_checker(mock_session):
+    def item_checker_function(item_type, response_object, item):
+        assert item.id == response_object['id']
+        assert isinstance(item, item_type)
+        assert item.response_object == response_object
+        assert item.session is mock_session
+
+    return item_checker_function
+
+
+def test_response_property(page_builder):
+    response = {1: 10, 2: 20, 3: 30}
+    page = page_builder(response)
+    assert response == page.response_object
+
+
+def test_getitem(page_builder, item_checker):
+    entry_1 = {
+        "type": "folder",
+        "id": "192429928",
+        "sequence_id": "1",
+        "etag": "1",
+        "name": "Stephen Curry Three Pointers"
+    }
+    entry_2 = {
+        "type": "file",
+        "id": "818853862",
+        "sequence_id": "0",
+        "etag": "0",
+        "name": "Warriors.jpg"
+    }
+    response_entries = [entry_1, entry_2]
+    response = {"entries": response_entries}
+    page = page_builder(response)
+
+    item_checker(Folder, entry_1, page[0])
+    item_checker(File, entry_2, page[1])
+    assert page[1] == page[-1]
+
+
+def test_getitem_past_length_raises(page_builder):
+    length = 7
+    response_entries = [object() for _ in range(length)]
+    response = {"entries": response_entries}
+    page = page_builder(response=response)
+
+    with pytest.raises(IndexError):
+        page[length]  # pylint:disable=pointless-statement
+
+
+@pytest.mark.parametrize('length', (0, 1, 10))
+def test_len(page_builder, length):
+    response_entries = [object() for _ in range(length)]
+    response = {
+        "entries": response_entries
+    }
+    page = page_builder(response=response)
+    assert len(page) == length
+
+
+def test_translation_of_page_entries(page_builder, mock_session, item_checker):
+    tested_item_types = ['folder', 'file', 'user', 'collaboration', 'group', 'foobar']
+    response_entries = [{'type': item_type_string, 'id': str(i)} for i, item_type_string in enumerate(tested_item_types)]
+    response = {"entries": response_entries}
+    page = page_builder(response=response)
+    for i, item in enumerate(page):
+        item_checker(mock_session.translator.translate(response_entries[i]['type']), response_entries[i], item)


### PR DESCRIPTION
Enable marker based pagination in the SDK, explicitly required for the [new Recents API](https://developer.box.com/v2.0/reference#get-recent-items)

Recents isn't compatible with the typical [limit/offset paging](https://developer.box.com/v2.0/reference#offset-based-paging) that most other endpoints use, and so [marker-based paging](https://developer.box.com/v2.0/reference#marker-based-paging) must be enabled. This PR adds explicit classes to support Limit/Offset pagination, as well as Marker pagination.