### PR TITLE
Prepare for next 2.0.0 alpha release

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -79,6 +79,14 @@ Release History
   the same as for ``Mapping``. That is, ``__contains__`` checks for JSON keys
   in the object, and ``__iter__`` yields all of the object's keys.
 
+- Added a ``RecentItem`` class.
+- Added ``client.get_recent_items()`` to retrieve a user's recently accessed items on Box.
+- Added ``BoxObjectCollection`` and subclasses ``LimitOffsetBasedObjectCollection`` and
+  ``MarkerBasedObjectCollection`` to more easily manage paging of objects from an endpoint.
+  These classes manage the logic of constructing requests to an endpoint and storing the results,
+  then provide ``__next__`` to easily iterate over the results. The option to return results one
+  by one or as a ``Page`` of results is also provided.
+
 **Other**
 
 - Added extra information to ``BoxAPIException``.

--- a/boxsdk/version.py
+++ b/boxsdk/version.py
@@ -3,4 +3,4 @@
 from __future__ import unicode_literals, absolute_import
 
 
-__version__ = '2.0.0a4'
+__version__ = '2.0.0a5'


### PR DESCRIPTION
Bump version to 2.0.0a5.

Add new release notes.

Add `RecentItem` and `client.get_recent_items()`.

Add `LimitOffsetBasedObjectCollection` and `MarkerBasedObjectCollection` for paging results from endpoints.