### PR TITLE
Support for passing RSA private key to JWTAuth

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -71,6 +71,11 @@ Release History
     the ``auto_session_renewal`` functionality of ``BoxSession``, this means
     that authentication for ``JWTAuth`` objects can be done completely
     automatically, at the time of first API call.
+  - The constructor now supports passing the RSA private key in two different
+    ways: by file system path (existing functionality), or by passing the key
+    data directly (new functionality). The ``rsa_private_key_file_sys_path``
+    parameter is now optional, but it is required to pass exactly one of
+    ``rsa_private_key_file_sys_path`` or ``rsa_private_key_data``.
   - Document that the ``enterprise_id`` argument to ``JWTAuth`` is allowed to
     be ``None``.
   - ``authenticate_instance()`` now accepts an ``enterprise`` argument, which

--- a/boxsdk/auth/jwt_auth.py
+++ b/boxsdk/auth/jwt_auth.py
@@ -338,7 +338,7 @@ class JWTAuth(OAuth2):
             'rsa_private_key_data must be binary data (bytes/str), '
             'a file-like object with a read() method, '
             'or an instance of RSAPrivateKey, '
-            'but got {!r}'
+            'but got {0!r}'
             .format(data.__class__.__name__)
         )
 
@@ -354,7 +354,7 @@ class JWTAuth(OAuth2):
                 )
         if not isinstance(passphrase, (binary_type, NoneType)):
             raise TypeError(
-                "rsa_private_key_passphrase must contain binary data (bytes/str), got {!r}"
+                "rsa_private_key_passphrase must contain binary data (bytes/str), got {0!r}"
                 .format(passphrase.__class__.__name__)
             )
         return passphrase

--- a/boxsdk/util/compat.py
+++ b/boxsdk/util/compat.py
@@ -7,6 +7,9 @@ from datetime import timedelta
 import six
 
 
+NoneType = type(None)
+
+
 if not hasattr(timedelta, 'total_seconds'):
     def total_seconds(delta):
         """

--- a/test/unit/util/test_api_call_decorator.py
+++ b/test/unit/util/test_api_call_decorator.py
@@ -66,12 +66,12 @@ def test_api_call_decorated_function_must_be_a_method():
 
 def test_api_call_decorated_method_must_be_a_cloneable_method():
 
-    class Cls(object):
+    class NonCloneable(object):
         @api_call
         def func(self):
             pass
 
-    obj = Cls()
+    obj = NonCloneable()
     with pytest.raises(TypeError):
         obj.func()
 


### PR DESCRIPTION
This allows a `JWTAuth` object to be initialized, without
requiring that the key be available to the process on disk.

Fixes #177.