### PR TITLE
Add functionality for auto-revoking auth tokens

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -53,6 +53,11 @@ Release History
 - When the ``auto_session_renewal`` is ``True`` when calling any of the request
   methods on ``BoxSession``, if there is no access token, ``BoxSession`` will
   renew the token _before_ making the request. This saves an API call.
+- Auth objects can now be closed, which prevents them from being used to
+  request new tokens. This will also revoke any existing tokens (though that
+  feature can be disabled by passing ``revoke=False``). Also introduces a
+  ``closing()`` context manager method, which will auto-close the auth object
+  on exit.
 - Various enhancements to the ``JWTAuth`` baseclass:
 
   - The ``authenticate_app_user()`` method is renamed to

--- a/boxsdk/version.py
+++ b/boxsdk/version.py
@@ -3,4 +3,4 @@
 from __future__ import unicode_literals, absolute_import
 
 
-__version__ = '2.0.0a6'
+__version__ = '2.0.0a7'

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,5 @@
+[pytest]
+addopts = --strict --showlocals -r a --tb=long
+xfail_strict = True
+junit_suite_name = boxsdk
+testpaths = test/

--- a/test/unit/auth/test_oauth2.py
+++ b/test/unit/auth/test_oauth2.py
@@ -413,7 +413,7 @@ def test_revoke_on_close(client_id, client_secret, access_token, mock_network_la
 
 def test_auth_object_is_closed_even_if_revoke_fails(client_id, client_secret, access_token, mock_network_layer):
     auth = OAuth2(client_id=client_id, client_secret=client_secret, access_token=access_token, network_layer=mock_network_layer)
-    with patch.object(auth, 'revoke', side_effect=BoxOAuthException(status=500)) as mock_revoke:
+    with patch.object(auth, 'revoke', side_effect=BoxOAuthException(status=500)):
         with pytest.raises(BoxOAuthException):
             auth.close(revoke=True)
     assert auth.closed is True

--- a/tox.ini
+++ b/tox.ini
@@ -20,7 +20,7 @@ envlist =
 
 [testenv]
 commands =
-  py.test test/ {posargs}
+  pytest {posargs}
 deps = -rrequirements-dev.txt
 
 [testenv:rst]


### PR DESCRIPTION
Auth objects can now be closed, which prevents them from being
used to request new tokens. This will also revoke any existing
tokens. Also introduces a `closing()` context manager method,
which will auto-close the auth object on exit. Clients can use
this to make sure that their tokens don't live longer than they
need them for.