### PR TITLE
Bug fix: impossible to use RedisManagedJWTAuth (closes #231)

### DIFF
--- a/boxsdk/auth/jwt_auth.py
+++ b/boxsdk/auth/jwt_auth.py
@@ -34,6 +34,7 @@ class JWTAuth(OAuth2):
             access_token=None,
             network_layer=None,
             jwt_algorithm='RS256',
+            refresh_lock=None,
     ):
         """
         :param client_id:
@@ -94,6 +95,7 @@ class JWTAuth(OAuth2):
             access_token=access_token,
             refresh_token=None,
             network_layer=network_layer,
+            refresh_lock=refresh_lock,
         )
         with open(rsa_private_key_file_sys_path, 'rb') as key_file:
             self._rsa_private_key = serialization.load_pem_private_key(


### PR DESCRIPTION
Fixes `__init__()` called from RedisManagedOAuth2Mixin with extra argument (`refresh_lock=`), which is absent in parent class.