### PR TITLE
Add support for view_path collabs

### DIFF
--- a/boxsdk/object/folder.py
+++ b/boxsdk/object/folder.py
@@ -408,7 +408,8 @@ class Folder(Item):
         :type notify:
             `bool`
         :param can_view_path:
-            Whether view path collaboration feature is enabled or not
+            Whether view path collaboration feature is enabled or not. Note - only
+            folder owners can create collaborations with can_view_path.
         :type can_view_path:
             `bool`
         :return:

--- a/boxsdk/object/folder.py
+++ b/boxsdk/object/folder.py
@@ -392,7 +392,7 @@ class Folder(Item):
         return self.update_info(data=data)
 
     @api_call
-    def add_collaborator(self, collaborator, role, notify=False):
+    def add_collaborator(self, collaborator, role, notify=False, can_view_path=False):
         """Add a collaborator to the folder
 
         :param collaborator:
@@ -407,6 +407,10 @@ class Folder(Item):
             Whether to send a notification email to the collaborator
         :type notify:
             `bool`
+        :param can_view_path:
+            Whether view path collaboration feature is enabled or not
+        :type can_view_path:
+            `bool`
         :return:
             The new collaboration
         :rtype:
@@ -418,13 +422,16 @@ class Folder(Item):
         access_key, access_value = collaborator_helper.access
         accessible_by = {
             access_key: access_value,
-            'type': collaborator_helper.type
+            'type': collaborator_helper.type,
         }
-        data = json.dumps({
+        body_params = {
             'item': item,
             'accessible_by': accessible_by,
             'role': role,
-        })
+        }
+        if can_view_path:
+            body_params['can_view_path'] = True
+        data = json.dumps(body_params)
         params = {'notify': notify}
         box_response = self._session.post(url, expect_json_response=True, data=data, params=params)
         collaboration_response = box_response.json()

--- a/test/unit/object/test_folder.py
+++ b/test/unit/object/test_folder.py
@@ -89,14 +89,14 @@ def test_add_collaborator(test_folder, mock_user, mock_group, mock_box_session, 
 
     invitee, mock_accessible_by = accessible_dict[accessible_by]
 
-    body_parems = {
+    body_params = {
         'item': {'id': test_folder.object_id, 'type': 'folder'},
         'accessible_by': mock_accessible_by,
         'role': role,
     }
     if can_view_path:
-        body_parems['can_view_path'] = True
-    data = json.dumps(body_parems)
+        body_params['can_view_path'] = True
+    data = json.dumps(body_params)
     _assert_collaborator_added(test_folder, invitee, mock_box_session, mock_collab_response, notify, role, can_view_path, data)
 
 


### PR DESCRIPTION
Adding ability to set the `can_view_path` body param when constructing
new folder collaborations.

ref: https://developer.box.com/v2.0/reference#add-a-collaboration