### PR TITLE
Add methods to configure JWT auth from a config file.

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -105,6 +105,8 @@ Release History
 - Added a ``downscope_token()`` method to the ``OAuth2`` class. This generates a token that
   has its permissions reduced to the provided scopes and for the optionally provided 
   ``File`` or ``Folder``.
+- Added methods for configuring `JWTAuth` from config file: `JWTAuth.from_config_file` and
+  `JWTAuth.from_config_dictionary`.
 
 **Other**
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -105,8 +105,8 @@ Release History
 - Added a ``downscope_token()`` method to the ``OAuth2`` class. This generates a token that
   has its permissions reduced to the provided scopes and for the optionally provided 
   ``File`` or ``Folder``.
-- Added methods for configuring `JWTAuth` from config file: `JWTAuth.from_config_file` and
-  `JWTAuth.from_config_dictionary`.
+- Added methods for configuring ``JWTAuth`` from config file: ``JWTAuth.from_config_file`` and
+  ``JWTAuth.from_config_dictionary``.
 
 **Other**
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -105,8 +105,8 @@ Release History
 - Added a ``downscope_token()`` method to the ``OAuth2`` class. This generates a token that
   has its permissions reduced to the provided scopes and for the optionally provided 
   ``File`` or ``Folder``.
-- Added methods for configuring ``JWTAuth`` from config file: ``JWTAuth.from_config_file`` and
-  ``JWTAuth.from_config_dictionary``.
+- Added methods for configuring ``JWTAuth`` from config file: ``JWTAuth.from_settings_file`` and
+  ``JWTAuth.from_settings_dictionary``.
 
 **Other**
 

--- a/boxsdk/auth/jwt_auth.py
+++ b/boxsdk/auth/jwt_auth.py
@@ -363,40 +363,40 @@ class JWTAuth(OAuth2):
         return passphrase
 
     @classmethod
-    def from_settings_dictionary(cls, config_dictionary, **kwargs):
+    def from_settings_dictionary(cls, settings_dictionary, **kwargs):
         """
         Create an auth instance as defined by the given settings dictionary.
 
         The dictionary should have the structure of the JSON file downloaded from the Box Developer Console.
 
-        :param config_dictionary:       Dictionary containing settings for configuring app auth.
-        :type config_dictionary:        `dict`
+        :param settings_dictionary:       Dictionary containing settings for configuring app auth.
+        :type settings_dictionary:        `dict`
         :return:                        Auth instance configured as specified by the config dictionary.
         :rtype:                         :class:`JWTAuth`
         """
-        if 'boxAppSettings' not in config_dictionary:
+        if 'boxAppSettings' not in settings_dictionary:
             raise ValueError('boxAppSettings not present in configuration')
         return cls(
-            client_id=config_dictionary['boxAppSettings']['clientID'],
-            client_secret=config_dictionary['boxAppSettings']['clientSecret'],
-            enterprise_id=config_dictionary.get('enterpriseID', None),
-            jwt_key_id=config_dictionary['boxAppSettings']['appAuth'].get('publicKeyID', None),
-            rsa_private_key_data=config_dictionary['boxAppSettings']['appAuth'].get('privateKey', None),
-            rsa_private_key_passphrase=config_dictionary['boxAppSettings']['appAuth'].get('passphrase', None),
+            client_id=settings_dictionary['boxAppSettings']['clientID'],
+            client_secret=settings_dictionary['boxAppSettings']['clientSecret'],
+            enterprise_id=settings_dictionary.get('enterpriseID', None),
+            jwt_key_id=settings_dictionary['boxAppSettings']['appAuth'].get('publicKeyID', None),
+            rsa_private_key_data=settings_dictionary['boxAppSettings']['appAuth'].get('privateKey', None),
+            rsa_private_key_passphrase=settings_dictionary['boxAppSettings']['appAuth'].get('passphrase', None),
             **kwargs
         )
 
     @classmethod
-    def from_config_file(cls, config_file_sys_path, **kwargs):
+    def from_settings_file(cls, settings_file_sys_path, **kwargs):
         """
         Create an auth instance as defined by a JSON file downloaded from the Box Developer Console.
         See https://developer.box.com/v2.0/docs/authentication-with-jwt for more information.
 
-        :param config_file_sys_path:    Path to the JSON file containing the configuration.
-        :type config_file_sys_path:     `unicode`
+        :param settings_file_sys_path:    Path to the JSON file containing the configuration.
+        :type settings_file_sys_path:     `unicode`
         :return:                        Auth instance configured as specified by the JSON file.
         :rtype:                         :class:`JWTAuth`
         """
-        with open(config_file_sys_path) as config_file:
+        with open(settings_file_sys_path) as config_file:
             config_dictionary = json.load(config_file)
             return cls.from_settings_dictionary(config_dictionary, **kwargs)

--- a/boxsdk/auth/jwt_auth.py
+++ b/boxsdk/auth/jwt_auth.py
@@ -363,23 +363,12 @@ class JWTAuth(OAuth2):
         return passphrase
 
     @classmethod
-    def from_config_dictionary(cls, config_dictionary):
+    def from_settings_dictionary(cls, config_dictionary, **kwargs):
         """
-        Create an auth instance as defined by the given configuration dictionary.
+        Create an auth instance as defined by the given settings dictionary.
 
-        The dictionary should have the following structure:
-        {
-            "boxAppSettings": {
-                "clientID": "<client ID>",
-                "clientSecret": "<client secret>",
-                "appAuth": {
-                    "publicKeyID": "<public key ID>",
-                    "privateKey": "<RSA private key data>",
-                    "passphrase": "<private key passphrase>",
-                }
-            },
-            "enterpriseID": "<enterprise ID>",
-        }
+        The dictionary should have the structure of the JSON file downloaded from the Box Developer Console.
+
         :param config_dictionary:       Dictionary containing settings for configuring app auth.
         :type config_dictionary:        `dict`
         :return:                        Auth instance configured as specified by the config dictionary.
@@ -390,16 +379,18 @@ class JWTAuth(OAuth2):
         return cls(
             client_id=config_dictionary['boxAppSettings']['clientID'],
             client_secret=config_dictionary['boxAppSettings']['clientSecret'],
-            enterprise_id=config_dictionary.get('enterpriseID'),
-            jwt_key_id=config_dictionary['boxAppSettings']['appAuth']['publicKeyID'],
-            rsa_private_key_data=config_dictionary['boxAppSettings']['appAuth']['privateKey'],
-            rsa_private_key_passphrase=config_dictionary['boxAppSettings']['appAuth']['passphrase'],
+            enterprise_id=config_dictionary.get('enterpriseID', None),
+            jwt_key_id=config_dictionary['boxAppSettings']['appAuth'].get('publicKeyID', None),
+            rsa_private_key_data=config_dictionary['boxAppSettings']['appAuth'].get('privateKey', None),
+            rsa_private_key_passphrase=config_dictionary['boxAppSettings']['appAuth'].get('passphrase', None),
+            **kwargs
         )
 
     @classmethod
-    def from_config_file(cls, config_file_sys_path):
+    def from_config_file(cls, config_file_sys_path, **kwargs):
         """
         Create an auth instance as defined by a JSON file downloaded from the Box Developer Console.
+        See https://developer.box.com/v2.0/docs/authentication-with-jwt for more information.
 
         :param config_file_sys_path:    Path to the JSON file containing the configuration.
         :type config_file_sys_path:     `unicode`
@@ -408,4 +399,4 @@ class JWTAuth(OAuth2):
         """
         with open(config_file_sys_path) as config_file:
             config_dictionary = json.load(config_file)
-            return cls.from_config_dictionary(config_dictionary)
+            return cls.from_settings_dictionary(config_dictionary, **kwargs)

--- a/test/unit/auth/test_jwt_auth.py
+++ b/test/unit/auth/test_jwt_auth.py
@@ -437,8 +437,8 @@ def assert_jwt_kwargs_expected(
         assert jwt_auth.kwargs['client_secret'] == fake_client_secret
         assert jwt_auth.kwargs['enterprise_id'] == fake_enterprise_id
         assert jwt_auth.kwargs['jwt_key_id'] == jwt_key_id
-        assert jwt_auth.kwargs['rsa_private_key_data'] == rsa_private_key_bytes
-        assert jwt_auth.kwargs['rsa_private_key_passphrase'] == rsa_passphrase
+        assert jwt_auth.kwargs['rsa_private_key_data'] == rsa_private_key_bytes.decode()
+        assert jwt_auth.kwargs['rsa_private_key_passphrase'] == (rsa_passphrase and rsa_passphrase.decode())
 
     return _assert_jwt_kwargs_expected
 
@@ -450,7 +450,7 @@ def test_from_config_file(
 ):
     # pylint:disable=redefined-outer-name
     with patch('boxsdk.auth.jwt_auth.open', mock_open(read_data=app_config_json_content), create=True):
-        jwt_auth_from_config_file = jwt_subclass_that_just_stores_params.from_config_file('fake_config_file_sys_path')
+        jwt_auth_from_config_file = jwt_subclass_that_just_stores_params.from_settings_file('fake_config_file_sys_path')
         assert_jwt_kwargs_expected(jwt_auth_from_config_file)
 
 

--- a/test/unit/auth/test_jwt_auth.py
+++ b/test/unit/auth/test_jwt_auth.py
@@ -418,7 +418,7 @@ def app_config_json_content(
         client_secret=fake_client_secret,
         jwt_key_id=jwt_key_id,
         private_key=rsa_private_key_bytes.replace(b"\n", b"\\n"),
-        passphrase=json.dumps(rsa_passphrase and text_type(rsa_passphrase)),
+        passphrase=json.dumps(rsa_passphrase and rsa_passphrase.decode()),
         enterprise_id=json.dumps(fake_enterprise_id),
     )
 

--- a/test/unit/auth/test_jwt_auth.py
+++ b/test/unit/auth/test_jwt_auth.py
@@ -418,7 +418,7 @@ def app_config_json_content(
         client_secret=fake_client_secret,
         jwt_key_id=jwt_key_id,
         private_key=rsa_private_key_bytes.replace(b"\n", b"\\n"),
-        passphrase=json.dumps(rsa_passphrase),
+        passphrase=json.dumps(rsa_passphrase and text_type(rsa_passphrase)),
         enterprise_id=json.dumps(fake_enterprise_id),
     )
 

--- a/test/unit/auth/test_jwt_auth.py
+++ b/test/unit/auth/test_jwt_auth.py
@@ -417,7 +417,7 @@ def app_config_json_content(
         client_id=fake_client_id,
         client_secret=fake_client_secret,
         jwt_key_id=jwt_key_id,
-        private_key=rsa_private_key_bytes.replace(b"\n", b"\\n"),
+        private_key=rsa_private_key_bytes.replace(b"\n", b"\\n").decode(),
         passphrase=json.dumps(rsa_passphrase and rsa_passphrase.decode()),
         enterprise_id=json.dumps(fake_enterprise_id),
     )

--- a/test/unit/auth/test_jwt_auth.py
+++ b/test/unit/auth/test_jwt_auth.py
@@ -400,7 +400,7 @@ def app_config_json_content(
         rsa_private_key_bytes,
         rsa_passphrase,
 ):
-    template = br"""
+    template = r"""
 {{
   "boxAppSettings": {{
     "clientID": "{client_id}",
@@ -417,7 +417,7 @@ def app_config_json_content(
         client_id=fake_client_id,
         client_secret=fake_client_secret,
         jwt_key_id=jwt_key_id,
-        private_key=rsa_private_key_bytes.replace(b"\n", b"\\n"),
+        private_key=rsa_private_key_bytes.replace("\n", "\\n"),
         passphrase=json.dumps(rsa_passphrase),
         enterprise_id=json.dumps(fake_enterprise_id),
     )

--- a/test/unit/auth/test_jwt_auth.py
+++ b/test/unit/auth/test_jwt_auth.py
@@ -417,7 +417,7 @@ def app_config_json_content(
         client_id=fake_client_id,
         client_secret=fake_client_secret,
         jwt_key_id=jwt_key_id,
-        private_key=rsa_private_key_bytes.replace("\n", "\\n"),
+        private_key=rsa_private_key_bytes.replace(b"\n", b"\\n"),
         passphrase=json.dumps(rsa_passphrase),
         enterprise_id=json.dumps(fake_enterprise_id),
     )


### PR DESCRIPTION
Fixes #221.

The Box developer console allows a developer to download a
configuration file that specifies how to configure a Box
application.

This commit adds code to parse these config files and apply
the configuration to a JWTAuth instance.