### PR TITLE
Automatically retry JWT auth API calls that fail because of the exp c…

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -86,6 +86,11 @@ Release History
   - ``authenticate_instance()`` now accepts an ``enterprise`` argument, which
     can be used to set and authenticate as the enterprise service account user,
     if ``None`` was passed for ``enterprise_id`` at construction time.
+  - Authentications that fail due to the expiration time not falling within the
+    correct window of time are now automatically retried using the time given
+    in the Date header of the Box API response. This can happen naturally when
+    the system time of the machine running the Box SDK doesn't agree with the
+    system time of the Box API servers.
 
 - Added an ``Event`` class.
 - Moved ``metadata()`` method to ``Item`` so it's now available for ``Folder``

--- a/boxsdk/auth/jwt_auth.py
+++ b/boxsdk/auth/jwt_auth.py
@@ -249,7 +249,7 @@ class JWTAuth(OAuth2):
                 error_description = json_response['error_description']
                 box_date_header = error_response.headers['date']
                 box_datetime = datetime.strptime(box_date_header, '%a, %d %b %Y %H:%M:%S %Z')
-            except:  # pylint:disable=broad-except
+            except Exception:  # pylint:disable=broad-except
                 pass
             else:
                 if status_code == 400 and 'exp' in error_description:

--- a/boxsdk/auth/jwt_auth.py
+++ b/boxsdk/auth/jwt_auth.py
@@ -246,7 +246,7 @@ class JWTAuth(OAuth2):
             box_datetime = self._get_date_header(error_response)
             if box_datetime is not None and self._was_exp_claim_rejected_due_to_clock_skew(error_response):
                 return self._construct_and_send_jwt_auth(sub, sub_type, box_datetime)
-        raise
+            raise
 
     @staticmethod
     def _get_date_header(network_response):

--- a/boxsdk/version.py
+++ b/boxsdk/version.py
@@ -3,4 +3,4 @@
 from __future__ import unicode_literals, absolute_import
 
 
-__version__ = '2.0.0a10'
+__version__ = '2.0.0a11'

--- a/test/unit/auth/test_jwt_auth.py
+++ b/test/unit/auth/test_jwt_auth.py
@@ -7,7 +7,6 @@ from datetime import datetime, timedelta
 import io
 from itertools import product
 import json
-import pytz
 import random
 import string
 
@@ -16,6 +15,7 @@ from cryptography.hazmat.primitives.asymmetric.rsa import RSAPrivateKey, generat
 from cryptography.hazmat.primitives import serialization
 from mock import Mock, mock_open, patch, sentinel, call
 import pytest
+import pytz
 import requests
 from six import binary_type, string_types, text_type
 


### PR DESCRIPTION
…laim.

JWT auth requires an expiration time, but legitimate authorization
requests can be rejected if the system times differ between the
request originator and the Box servers.

This commit adds logic to detect this situation and automatically retry.
The Box servers include a ``Date`` header when the auth request is
rejected due to the exp claim, so we use that value to construct the
new claim.