### PR TITLE
Fix the build for python 2.6 and python 3.3.

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,12 +1,1 @@
--r requirements.txt
-bottle
-jsonpatch
-mock>=2.0.0
-pep8
-pylint
-pytest>=2.8.3
-pytest-cov
-pytest-xdist
-sphinx>=1.5,<1.6
-sqlalchemy
-tox
+-e .[test,all]

--- a/setup.py
+++ b/setup.py
@@ -83,6 +83,23 @@ def main():
             python_conditional = 'python_version=="{0}"'.format(python_version)
             key = ':{0}'.format(python_conditional)
             extra_requires[key].append(requirement)
+    test_requires = [
+        'bottle',
+        'jsonpatch',
+        'mock>=2.0.0',
+        'pep8', 'pylint',
+        'sqlalchemy',
+        'tox',
+        'pytest-cov',
+        'pytest-xdist',
+        'pytz',
+    ]
+    # pytest>=3.3.0 has dropped support for python 2.6 and 3.3; we pin lower than 3.3.0 for those python versions
+    if sys.version_info[:2] <= (2, 6) or (sys.version_info[0] == 3 and sys.version_info[1] <= 3):
+        test_requires.append('pytest>=2.8.3,<3.3.0')
+    else:
+        test_requires.append('pytest>=2.8.3')
+    extra_requires['test'] = test_requires
     with open('boxsdk/version.py', 'r', encoding='utf-8') as config_py:
         version = re.search(r'^\s+__version__\s*=\s*[\'"]([^\'"]*)[\'"]', config_py.read(), re.MULTILINE).group(1)
     setup(
@@ -96,7 +113,7 @@ def main():
         packages=find_packages(exclude=['demo', 'docs', 'test', 'test*', '*test', '*test*']),
         install_requires=install_requires,
         extras_require=extra_requires,
-        tests_require=['pytest', 'pytest-xdist', 'mock', 'sqlalchemy', 'bottle', 'jsonpatch'],
+        tests_require=test_requires,
         cmdclass={'test': PyTest},
         classifiers=CLASSIFIERS,
         keywords='box oauth2 sdk',


### PR DESCRIPTION
The latest version of pytest (3.3.0) dropped support for these
python versions, so we need to install an older version when
we're being run on one of them.