### PR TITLE
Add session-specific conf.

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -116,6 +116,7 @@ Release History
 - Added methods for configuring ``JWTAuth`` from config file: ``JWTAuth.from_settings_file`` and
   ``JWTAuth.from_settings_dictionary``.
 - Added ``network_response`` property to ``BoxOAuthException``.
+- API Configuration can now be done per ``BoxSession`` instance.
 
 **Other**
 

--- a/boxsdk/auth/oauth2.py
+++ b/boxsdk/auth/oauth2.py
@@ -109,6 +109,7 @@ class OAuth2(object):
         self._box_device_id = box_device_id
         self._box_device_name = box_device_name
         self._closed = False
+        self._api_config = API()
 
     @property
     def access_token(self):
@@ -131,6 +132,14 @@ class OAuth2(object):
         :rtype:   `bool`
         """
         return self._closed
+
+    @property
+    def api_config(self):
+        """
+
+        :rtype:     :class:`API`
+        """
+        return self._api_config
 
     def get_authorization_url(self, redirect_url):
         """
@@ -162,7 +171,7 @@ class OAuth2(object):
         # encode the parameters as ASCII bytes.
         params = [(key.encode('utf-8'), value.encode('utf-8')) for (key, value) in params]
         query_string = urlencode(params)
-        return urlunsplit(('', '', API.OAUTH2_AUTHORIZE_URL, query_string, '')), csrf_token
+        return urlunsplit(('', '', self._api_config.OAUTH2_AUTHORIZE_URL, query_string, '')), csrf_token
 
     def authenticate(self, auth_code):
         """
@@ -320,7 +329,7 @@ class OAuth2(object):
             :class:`TokenResponse`
         """
         self._check_closed()
-        url = '{base_auth_url}/token'.format(base_auth_url=API.OAUTH2_API_URL)
+        url = '{base_auth_url}/token'.format(base_auth_url=self._api_config.OAUTH2_API_URL)
         headers = {'content-type': 'application/x-www-form-urlencoded'}
         network_response = self._network_layer.request(
             'POST',
@@ -373,7 +382,7 @@ class OAuth2(object):
             token_to_revoke = access_token or refresh_token
             if token_to_revoke is None:
                 return
-            url = '{base_auth_url}/revoke'.format(base_auth_url=API.OAUTH2_API_URL)
+            url = '{base_auth_url}/revoke'.format(base_auth_url=self._api_config.OAUTH2_API_URL)
             network_response = self._network_layer.request(
                 'POST',
                 url,

--- a/boxsdk/client/client.py
+++ b/boxsdk/client/client.py
@@ -4,7 +4,6 @@ from __future__ import unicode_literals, absolute_import
 import json
 
 from ..auth.oauth2 import TokenResponse
-from ..config import API
 from ..session.box_session import BoxSession
 from ..network.default_network import DefaultNetwork
 from ..object.cloneable import Cloneable

--- a/boxsdk/client/client.py
+++ b/boxsdk/client/client.py
@@ -166,7 +166,7 @@ class Client(Cloneable):
         :rtype:
             `list` of :class:`User`
         """
-        url = '{0}/users'.format(API.BASE_API_URL)
+        url = self.get_url('users')
         params = dict(offset=offset)
         if limit is not None:
             params['limit'] = limit
@@ -278,7 +278,7 @@ class Client(Cloneable):
         :rtype:
             `list` of :class:`Group`
         """
-        url = '{0}/groups'.format(API.BASE_API_URL)
+        url = self.get_url('groups')
         box_response = self._session.get(url)
         response = box_response.json()
         group_class = self.translator.translate('group')
@@ -304,7 +304,7 @@ class Client(Cloneable):
         :raises:
             :class:`BoxAPIException` if current user doesn't have permissions to create a group.
         """
-        url = '{0}/groups'.format(API.BASE_API_URL)
+        url = self.get_url('groups')
         body_attributes = {
             'name': name,
         }
@@ -375,7 +375,7 @@ class Client(Cloneable):
         """
         response = self.make_request(
             'GET',
-            '{0}/shared_items'.format(API.BASE_API_URL),
+            self.get_url('shared_items'),
             headers=get_shared_link_header(shared_link, password),
         ).json()
         return self.translator.translate(response['type'])(
@@ -425,7 +425,7 @@ class Client(Cloneable):
             https://box-content.readme.io/#create-an-enterprise-user for enterprise users
             or https://box-content.readme.io/docs/app-users for app users.
         """
-        url = '{0}/users'.format(API.BASE_API_URL)
+        url = self.get_url('users')
         user_attributes['name'] = name
         if login is not None:
             user_attributes['login'] = login
@@ -461,7 +461,7 @@ class Client(Cloneable):
         :rtype:
             :class:`TokenResponse`
         """
-        url = '{base_auth_url}/token'.format(base_auth_url=API.OAUTH2_API_URL)
+        url = '{base_auth_url}/token'.format(base_auth_url=self._session.api_config.OAUTH2_API_URL)
         data = {
             'subject_token': self.auth.access_token,
             'subject_token_type': 'urn:ietf:params:oauth:token-type:access_token',

--- a/boxsdk/object/file.py
+++ b/boxsdk/object/file.py
@@ -2,7 +2,6 @@
 
 from __future__ import unicode_literals
 
-from boxsdk.config import API
 from .item import Item
 from ..util.api_call_decorator import api_call
 

--- a/boxsdk/object/file.py
+++ b/boxsdk/object/file.py
@@ -122,7 +122,10 @@ class File(Item):
         if preflight_check:
             self.preflight_check(size=preflight_expected_size)
 
-        url = self.get_url('content').replace(API.BASE_API_URL, API.UPLOAD_URL)
+        url = self.get_url('content').replace(
+            self._session.api_config.BASE_API_URL,
+            self._session.api_config.UPLOAD_URL,
+        )
         if upload_using_accelerator:
             accelerator_upload_url = self._get_accelerator_upload_url_for_update()
             if accelerator_upload_url:

--- a/boxsdk/object/folder.py
+++ b/boxsdk/object/folder.py
@@ -266,7 +266,7 @@ class Folder(Item):
         if preflight_check:
             self.preflight_check(size=preflight_expected_size, name=file_name)
 
-        url = '{0}/files/content'.format(API.UPLOAD_URL)
+        url = '{0}/files/content'.format(self._session.api_config.UPLOAD_URL)
         if upload_using_accelerator:
             accelerator_upload_url = self._get_accelerator_upload_url_fow_new_uploads()
             if accelerator_upload_url:
@@ -418,7 +418,7 @@ class Folder(Item):
             :class:`Collaboration`
         """
         collaborator_helper = _Collaborator(collaborator)
-        url = API.BASE_API_URL + '/collaborations'
+        url = self._session.get_url('collaborations')
         item = {'id': self._object_id, 'type': 'folder'}
         access_key, access_value = collaborator_helper.access
         accessible_by = {

--- a/boxsdk/object/folder.py
+++ b/boxsdk/object/folder.py
@@ -5,7 +5,6 @@ import json
 import os
 from six import text_type
 
-from boxsdk.config import API
 from boxsdk.object.group import Group
 from boxsdk.object.item import Item
 from boxsdk.object.user import User

--- a/boxsdk/object/group.py
+++ b/boxsdk/object/group.py
@@ -5,7 +5,6 @@ from functools import partial
 import json
 
 from .base_object import BaseObject
-from ..config import API
 from ..util.api_call_decorator import api_call
 
 
@@ -73,7 +72,7 @@ class Group(BaseObject):
         :rtype:
             :class:`GroupMembership`
         """
-        url = '{0}/group_memberships'.format(API.BASE_API_URL)
+        url = self._session.get_url('group_memberships')
         body_attributes = {
             'user': {'id': user.object_id},
             'group': {'id': self.object_id},

--- a/boxsdk/object/item.py
+++ b/boxsdk/object/item.py
@@ -27,7 +27,7 @@ class Item(BaseObject):
             `unicode` or None
         """
         endpoint = '{0}/content'.format(file_id) if file_id else 'content'
-        url = '{0}/files/{1}'.format(API.BASE_API_URL, endpoint)
+        url = '{0}/files/{1}'.format(self._session.api_config.BASE_API_URL, endpoint)
         try:
             response_json = self._session.options(
                 url=url,
@@ -63,7 +63,7 @@ class Item(BaseObject):
             :class:`BoxAPIException` when preflight check fails.
         """
         endpoint = '{0}/content'.format(file_id) if file_id else 'content'
-        url = '{0}/files/{1}'.format(API.BASE_API_URL, endpoint)
+        url = '{0}/files/{1}'.format(self._session.api_config.BASE_API_URL, endpoint)
         data = {'size': size}
         if name:
             data['name'] = name

--- a/boxsdk/object/item.py
+++ b/boxsdk/object/item.py
@@ -4,7 +4,6 @@ from __future__ import unicode_literals, absolute_import
 import json
 
 from .base_object import BaseObject
-from ..config import API
 from ..exception import BoxAPIException
 from .metadata import Metadata
 from ..util.api_call_decorator import api_call

--- a/boxsdk/session/box_session.py
+++ b/boxsdk/session/box_session.py
@@ -66,7 +66,16 @@ class BoxSession(object):
     Box API session. Provides auth, automatic retry of failed requests, and session renewal.
     """
 
-    def __init__(self, oauth, network_layer, default_headers=None, translator=None, default_network_request_kwargs=None):
+    def __init__(
+            self,
+            oauth,
+            network_layer,
+            default_headers=None,
+            translator=None,
+            default_network_request_kwargs=None,
+            api_config=None,
+            client_config=None,
+    ):
         """
         :param oauth:
             OAuth2 object used by the session to authorize requests.
@@ -91,13 +100,23 @@ class BoxSession(object):
             when this session makes an API request.
         :type default_network_request_kwargs:
             `dict` or None
+        :param api_config:
+            Object containing URLs for the Box API.
+        :type api_config:
+            :class:`API`
+        :param client_config:
+            Object containing client information, including user agent string.
+        :type client_config:
+            :class:`Client`
         """
         if translator is None:
             translator = Translator(extend_default_translator=True, new_child=True)
+        self._api_config = api_config or API()
+        self._client_config = client_config or Client()
         super(BoxSession, self).__init__()
         self._oauth = oauth
         self._network_layer = network_layer
-        self._default_headers = {'User-Agent': Client.USER_AGENT_STRING}
+        self._default_headers = {'User-Agent': self._client_config.USER_AGENT_STRING}
         self._translator = translator
         self._default_network_request_kwargs = {}
         if default_headers:
@@ -112,6 +131,22 @@ class BoxSession(object):
         :rtype:   :class:`Translator`
         """
         return self._translator
+
+    @property
+    def api_config(self):
+        """
+
+        :rtype:     :class:`API`
+        """
+        return self._api_config
+
+    @property
+    def client_config(self):
+        """
+
+        :rtype:     :class:`Client`
+        """
+        return self._client_config
 
     def get_url(self, endpoint, *args):
         """
@@ -129,7 +164,7 @@ class BoxSession(object):
             `unicode`
         """
         # pylint:disable=no-self-use
-        url = ['{0}/{1}'.format(API.BASE_API_URL, endpoint)]
+        url = ['{0}/{1}'.format(self._api_config.BASE_API_URL, endpoint)]
         url.extend(['/{0}'.format(x) for x in args])
         return ''.join(url)
 
@@ -150,6 +185,8 @@ class BoxSession(object):
             default_headers=headers,
             translator=self._translator,
             default_network_request_kwargs=self._default_network_request_kwargs.copy(),
+            api_config=self._api_config,
+            client_config=self._client_config,
         )
 
     def with_shared_link(self, shared_link, shared_link_password=None):
@@ -173,6 +210,8 @@ class BoxSession(object):
             default_headers=headers,
             translator=self._translator,
             default_network_request_kwargs=self._default_network_request_kwargs.copy(),
+            api_config=self._api_config,
+            client_config=self._client_config,
         )
 
     def with_default_network_request_kwargs(self, extra_network_parameters):
@@ -182,6 +221,8 @@ class BoxSession(object):
             default_headers=self._default_headers.copy(),
             translator=self._translator,
             default_network_request_kwargs=extra_network_parameters,
+            api_config=self._api_config,
+            client_config=self._client_config,
         )
 
     def _renew_session(self, access_token_used):

--- a/boxsdk/version.py
+++ b/boxsdk/version.py
@@ -3,4 +3,4 @@
 from __future__ import unicode_literals, absolute_import
 
 
-__version__ = '2.0.0a11'
+__version__ = '2.0.0a12'

--- a/test/unit/conftest.py
+++ b/test/unit/conftest.py
@@ -59,8 +59,10 @@ def mock_box_session(translator):
 @pytest.fixture()
 def mock_box_session_2():
     mock_session = MagicMock(BoxSession)
+    # pylint:disable=protected-access
     mock_session._api_config = API()
     mock_session._client_config = Client()
+    # pylint:enable=protected-access
     mock_session.get_url.side_effect = lambda *args, **kwargs: BoxSession.get_url(mock_session, *args, **kwargs)
     return mock_session
 

--- a/test/unit/conftest.py
+++ b/test/unit/conftest.py
@@ -7,7 +7,9 @@ import json
 
 from mock import Mock, MagicMock
 import pytest
+
 from boxsdk.auth.oauth2 import DefaultNetwork
+from boxsdk.config import API, Client
 from boxsdk.network import default_network
 from boxsdk.network.default_network import DefaultNetworkResponse
 from boxsdk.session.box_session import BoxResponse, BoxSession
@@ -45,6 +47,10 @@ def translator(default_translator):   # pylint:disable=unused-argument
 @pytest.fixture(scope='function')
 def mock_box_session(translator):
     mock_session = MagicMock(BoxSession)
+    # pylint:disable=protected-access
+    mock_session._api_config = mock_session.api_config = API()
+    mock_session._client_config = mock_session.client_config = Client()
+    # pylint:enable=protected-access
     mock_session.get_url.side_effect = lambda *args, **kwargs: BoxSession.get_url(mock_session, *args, **kwargs)
     mock_session.translator = translator
     return mock_session
@@ -53,6 +59,8 @@ def mock_box_session(translator):
 @pytest.fixture()
 def mock_box_session_2():
     mock_session = MagicMock(BoxSession)
+    mock_session._api_config = API()
+    mock_session._client_config = Client()
     mock_session.get_url.side_effect = lambda *args, **kwargs: BoxSession.get_url(mock_session, *args, **kwargs)
     return mock_session
 

--- a/test/unit/session/test_box_session.py
+++ b/test/unit/session/test_box_session.py
@@ -10,6 +10,7 @@ from mock import MagicMock, Mock, PropertyMock, call
 import pytest
 
 from boxsdk.auth.oauth2 import OAuth2
+from boxsdk.config import API
 from boxsdk.exception import BoxAPIException
 from boxsdk.network.default_network import DefaultNetwork, DefaultNetworkResponse
 from boxsdk.session.box_session import BoxSession, BoxResponse, Translator
@@ -251,3 +252,18 @@ def test_translator(box_session, translator, default_translator, original_defaul
     # Test that adding new registrations does not affect global state.
     assert default_translator == original_default_translator
     assert (set(box_session.translator) - set(default_translator)) == set([item_type])
+
+
+def test_session_uses_global_config(box_session, mock_network_layer, generic_successful_response, monkeypatch):
+    mock_network_layer.request.side_effect = generic_successful_response
+    example_dot_com = 'https://example.com/'
+    monkeypatch.setattr(API, 'BASE_API_URL', example_dot_com)
+    assert example_dot_com in box_session.get_url('foo', 'bar')
+
+
+def test_session_uses_local_config(box_session, mock_network_layer, generic_successful_response, monkeypatch):
+    mock_network_layer.request.side_effect = generic_successful_response
+    example_dot_com = 'https://example.com/'
+    box_session.api_config.BASE_API_URL = example_dot_com
+    monkeypatch.setattr(API, 'BASE_API_URL', 'https://api.box.com')
+    assert example_dot_com in box_session.get_url('foo', 'bar')


### PR DESCRIPTION
Currently, configuration values like user-agent
and API urls are essentially global variables.

This commit adds config to the BoxSession, allowing
each session to override config values.