### PR TITLE
Skip CI on feature branch push

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,11 @@
 sudo: false
 language: python
 
+branches:
+    only:
+        - master
+        - "1.5"
+
 cache:
   directories:
     - $HOME/.cache/pip


### PR DESCRIPTION
In order to make CI run more quickly for PRs, we can skip running tests on push to feature branches (since those will be tested by the PR CI job already).  Pushes on "stable" branches will still be run.