### PR TITLE
Add type check in logging sanitizer

### DIFF
--- a/boxsdk/util/log.py
+++ b/boxsdk/util/log.py
@@ -59,7 +59,7 @@ class Logging(object):
             return dictionary
         sanitized_dictionary = {}
         for key, value in iteritems(dictionary):
-            if key in self.KEYS_TO_SANITIZE:
+            if key in self.KEYS_TO_SANITIZE and isinstance(value, string_types):
                 sanitized_dictionary[key] = self.sanitize_value(value)
             elif isinstance(value, Mapping):
                 sanitized_dictionary[key] = self.sanitize_dictionary(value)


### PR DESCRIPTION
Log sanitization should not attempt to sanitize non-string values,
since they are not guaranteed to be subscriptable.