### PR TITLE
Refactor auth to use the session.

### DIFF
--- a/boxsdk/auth/jwt_auth.py
+++ b/boxsdk/auth/jwt_auth.py
@@ -38,7 +38,7 @@ class JWTAuth(OAuth2):
             box_device_id='0',
             box_device_name='',
             access_token=None,
-            network_layer=None,
+            session=None,
             jwt_algorithm='RS256',
             rsa_private_key_data=None,
             **kwargs
@@ -150,7 +150,7 @@ class JWTAuth(OAuth2):
             box_device_name=box_device_name,
             access_token=access_token,
             refresh_token=None,
-            network_layer=network_layer,
+            session=session,
             **kwargs
         )
         self._rsa_private_key = rsa_private_key

--- a/boxsdk/client/developer_token_client.py
+++ b/boxsdk/client/developer_token_client.py
@@ -10,9 +10,8 @@ class DeveloperTokenClient(Client):
     """
     Box client subclass which authorizes with a developer token.
     """
-    def __init__(self, oauth=None, network_layer=None, session=None):
+    def __init__(self, oauth=None, session=None):
         super(DeveloperTokenClient, self).__init__(
             oauth=oauth or DeveloperTokenAuth(),
-            network_layer=network_layer,
             session=session,
         )

--- a/boxsdk/session/session.py
+++ b/boxsdk/session/session.py
@@ -397,6 +397,7 @@ class Session(object):
         :rtype:
             `callable`
         """
+        # pylint:disable=unused-argument
         code = network_response.status_code
         if code in (202, 429) or code >= 500:
             return partial(
@@ -453,7 +454,7 @@ class AuthorizedSession(Session):
     Box API authorized session. Provides auth, automatic retry of failed requests, and session renewal.
     """
 
-    def __init__(self, oauth, *args, **kwargs):
+    def __init__(self, oauth, **kwargs):
         """
         :param oauth:
             OAuth2 object used by the session to authorize requests.

--- a/boxsdk/session/session.py
+++ b/boxsdk/session/session.py
@@ -9,21 +9,20 @@ from .box_request import BoxRequest as _BoxRequest
 from .box_response import BoxResponse as _BoxResponse
 from ..config import API, Client
 from ..exception import BoxAPIException
+from ..network.default_network import DefaultNetwork
 from ..util.json import is_json_response
 from ..util.multipart_stream import MultipartStream
 from ..util.shared_link import get_shared_link_header
 from ..util.translator import Translator
 
 
-class BoxSession(object):
+class Session(object):
     """
-    Box API session. Provides auth, automatic retry of failed requests, and session renewal.
+    Box API session. Provides automatic retry of failed requests.
     """
-
     def __init__(
             self,
-            oauth,
-            network_layer,
+            network_layer=None,
             default_headers=None,
             translator=None,
             default_network_request_kwargs=None,
@@ -31,10 +30,6 @@ class BoxSession(object):
             client_config=None,
     ):
         """
-        :param oauth:
-            OAuth2 object used by the session to authorize requests.
-        :type oauth:
-            :class:`OAuth2`
         :param network_layer:
             Network implementation used by the session to make requests.
         :type network_layer:
@@ -67,9 +62,8 @@ class BoxSession(object):
             translator = Translator(extend_default_translator=True, new_child=True)
         self._api_config = api_config or API()
         self._client_config = client_config or Client()
-        super(BoxSession, self).__init__()
-        self._oauth = oauth
-        self._network_layer = network_layer
+        super(Session, self).__init__()
+        self._network_layer = network_layer or DefaultNetwork()
         self._default_headers = {'User-Agent': self._client_config.USER_AGENT_STRING}
         self._translator = translator
         self._default_network_request_kwargs = {}
@@ -78,6 +72,73 @@ class BoxSession(object):
         if default_network_request_kwargs:
             self._default_network_request_kwargs.update(default_network_request_kwargs)
         self._logger = getLogger(__name__)
+
+    def get(self, url, **kwargs):
+        """Make a GET request to the Box API.
+
+        :param url:
+            The URL for the request.
+        :type url:
+            `unicode`
+        """
+        return self.request('GET', url, **kwargs)
+
+    def post(self, url, **kwargs):
+        """Make a POST request to the Box API.
+
+        :param url:
+            The URL for the request.
+        :type url:
+            `unicode`
+        """
+        return self.request('POST', url, **kwargs)
+
+    def put(self, url, **kwargs):
+        """Make a PUT request to the Box API.
+
+        :param url:
+            The URL for the request.
+        :type url:
+            `unicode`
+        """
+        return self.request('PUT', url, **kwargs)
+
+    def delete(self, url, **kwargs):
+        """Make a DELETE request to the Box API.
+
+        :param url:
+            The URL for the request.
+        :type url:
+            `unicode`
+        """
+        if 'expect_json_response' not in kwargs:
+            kwargs['expect_json_response'] = False
+        return self.request('DELETE', url, **kwargs)
+
+    def options(self, url, **kwargs):
+        """Make an OPTIONS request to the Box API.
+
+        :param url:
+            The URL for the request.
+        :type url:
+            `unicode`
+        """
+        return self.request('OPTIONS', url, **kwargs)
+
+    def request(self, method, url, **kwargs):
+        """Make a request to the Box API.
+
+        :param method:
+            The HTTP verb for the request.
+        :type method:
+            `unicode`
+        :param url:
+            The URL for the request.
+        :type url:
+            `unicode`
+        """
+        response = self._prepare_and_send_request(method, url, **kwargs)
+        return self.box_response_constructor(response)
 
     @property
     def box_request_constructor(self):
@@ -133,6 +194,16 @@ class BoxSession(object):
         url.extend(['/{0}'.format(x) for x in args])
         return ''.join(url)
 
+    def get_constructor_kwargs(self):
+        return dict(
+            network_layer=self._network_layer,
+            translator=self._translator,
+            default_network_request_kwargs=self._default_network_request_kwargs.copy(),
+            api_config=self._api_config,
+            client_config=self._client_config,
+            default_headers=self._default_headers.copy(),
+        )
+
     def as_user(self, user):
         """
         Returns a new session object with default headers set up to make requests as the specified user.
@@ -142,17 +213,9 @@ class BoxSession(object):
         :type user:
             :class:`User`
         """
-        headers = self._default_headers.copy()
-        headers['As-User'] = user.object_id
-        return self.__class__(
-            self._oauth,
-            self._network_layer,
-            default_headers=headers,
-            translator=self._translator,
-            default_network_request_kwargs=self._default_network_request_kwargs.copy(),
-            api_config=self._api_config,
-            client_config=self._client_config,
-        )
+        kwargs = self.get_constructor_kwargs()
+        kwargs['default_headers']['As-User'] = user.object_id
+        return self.__class__(**kwargs)
 
     def with_shared_link(self, shared_link, shared_link_password=None):
         """
@@ -167,40 +230,14 @@ class BoxSession(object):
         :type shared_link_password:
             `unicode`
         """
-        headers = self._default_headers.copy()
-        headers.update(get_shared_link_header(shared_link, shared_link_password))
-        return self.__class__(
-            self._oauth,
-            self._network_layer,
-            default_headers=headers,
-            translator=self._translator,
-            default_network_request_kwargs=self._default_network_request_kwargs.copy(),
-            api_config=self._api_config,
-            client_config=self._client_config,
-        )
+        kwargs = self.get_constructor_kwargs()
+        kwargs['default_headers'].update(get_shared_link_header(shared_link, shared_link_password))
+        return self.__class__(**kwargs)
 
     def with_default_network_request_kwargs(self, extra_network_parameters):
-        return self.__class__(
-            self._oauth,
-            self._network_layer,
-            default_headers=self._default_headers.copy(),
-            translator=self._translator,
-            default_network_request_kwargs=extra_network_parameters,
-            api_config=self._api_config,
-            client_config=self._client_config,
-        )
-
-    def _renew_session(self, access_token_used):
-        """
-        Renews the session by refreshing the access token.
-
-        :param access_token_used:
-            The access token that's currently being used by the session, that needs to be refreshed.
-        :type access_token_used:
-            `unicode` or None
-        """
-        new_access_token, _ = self._oauth.refresh(access_token_used)
-        return new_access_token
+        kwargs = self.get_constructor_kwargs()
+        kwargs['default_network_request_kwargs'].update(extra_network_parameters)
+        return self.__class__(**kwargs)
 
     def _get_retry_after_time(self, attempt_number, retry_after_header):
         """
@@ -222,47 +259,6 @@ class BoxSession(object):
         if retry_after_header is not None:
             return float(retry_after_header)
         return 2 ** attempt_number
-
-    def _get_retry_request_callable(self, network_response, attempt_number, request):
-        """
-        Get a callable that retries a request for certain types of failure.
-
-        For 401 Unauthorized responses, renew the session by refreshing the access token; then retry.
-        For 202 Accepted (thumbnail or file not ready) and 429 (too many requests), retry later, after a delay
-        specified by the Retry-After header.
-        For 5xx Server Error, retry later, after a delay; use exponential backoff to determine the delay.
-
-        Otherwise, return None.
-
-        :param network_response:
-            The response from the Box API.
-        :type network_response:
-            :class:`NetworkResponse`
-        :param attempt_number:
-            How many attempts at this request have already been tried. Used for exponential backoff calculations.
-        :type attempt_number:
-            `int`
-        :param request:
-            The API request that could require retrying.
-        :type request:
-            :class:`BoxRequest`
-        :return:
-            Callable that, when called, will retry the request. Takes the same parameters as :meth:`_send_request`.
-        :rtype:
-            `callable`
-        """
-        code = network_response.status_code
-        if code == 401 and request.auto_session_renewal:
-            self._renew_session(network_response.access_token_used)
-            request.auto_session_renewal = False
-            return self._send_request
-        elif code in (202, 429) or code >= 500:
-            return partial(
-                self._network_layer.retry_after,
-                self._get_retry_after_time(attempt_number, network_response.headers.get('Retry-After', None)),
-                self._send_request,
-            )
-        return None
 
     @staticmethod
     def _raise_on_unsuccessful_request(network_response, request):
@@ -347,11 +343,13 @@ class BoxSession(object):
         if files:
             kwargs['file_stream_positions'] = dict((name, file_tuple[1].tell()) for name, file_tuple in files.items())
         attempt_number = 0
+        request_headers = self._get_request_headers()
+        request_headers.update(headers or {})
 
         request = self.box_request_constructor(
             url=url,
             method=method,
-            headers=headers,
+            headers=request_headers,
             auto_session_renewal=auto_session_renewal,
             expect_json_response=expect_json_response,
         )
@@ -371,6 +369,156 @@ class BoxSession(object):
         self._raise_on_unsuccessful_request(network_response, request)
 
         return network_response
+
+    def _get_retry_request_callable(self, network_response, attempt_number, request):
+        """
+        Get a callable that retries a request for certain types of failure.
+
+        For 202 Accepted (thumbnail or file not ready) and 429 (too many requests), retry later, after a delay
+        specified by the Retry-After header.
+        For 5xx Server Error, retry later, after a delay; use exponential backoff to determine the delay.
+
+        Otherwise, return None.
+
+        :param network_response:
+            The response from the Box API.
+        :type network_response:
+            :class:`NetworkResponse`
+        :param attempt_number:
+            How many attempts at this request have already been tried. Used for exponential backoff calculations.
+        :type attempt_number:
+            `int`
+        :param request:
+            The API request that could require retrying.
+        :type request:
+            :class:`BoxRequest`
+        :return:
+            Callable that, when called, will retry the request. Takes the same parameters as :meth:`_send_request`.
+        :rtype:
+            `callable`
+        """
+        code = network_response.status_code
+        if code in (202, 429) or code >= 500:
+            return partial(
+                self._network_layer.retry_after,
+                self._get_retry_after_time(attempt_number, network_response.headers.get('Retry-After', None)),
+                self._send_request,
+            )
+        return None
+
+    def _get_request_headers(self):
+        return self._default_headers.copy()
+
+    def _send_request(self, request, **kwargs):
+        """
+        Make a request to the Box API.
+
+        :param request:
+            The API request to send.
+        :type request:
+            :class:`BoxRequest`
+        :param expect_json_response:
+            Whether or not the response content should be json.
+        :type expect_json_response:
+            `bool`
+        """
+        # Reset stream positions to what they were when the request was made so the same data is sent even if this
+        # is a retried attempt.
+        files, file_stream_positions = kwargs.get('files'), kwargs.pop('file_stream_positions')
+        request_kwargs = self._default_network_request_kwargs.copy()
+        request_kwargs.update(kwargs)
+        if files and file_stream_positions:
+            for name, position in file_stream_positions.items():
+                files[name][1].seek(position)
+            data = request_kwargs.pop('data', {})
+            multipart_stream = MultipartStream(data, files)
+            request_kwargs['data'] = multipart_stream
+            del request_kwargs['files']
+            request.headers['Content-Type'] = multipart_stream.content_type
+
+        # send the request
+        network_response = self._network_layer.request(
+            request.method,
+            request.url,
+            access_token=request_kwargs.pop('access_token', None),
+            headers=request.headers,
+            **request_kwargs
+        )
+
+        return network_response
+
+
+class AuthorizedSession(Session):
+    """
+    Box API authorized session. Provides auth, automatic retry of failed requests, and session renewal.
+    """
+
+    def __init__(self, oauth, *args, **kwargs):
+        """
+        :param oauth:
+            OAuth2 object used by the session to authorize requests.
+        :type oauth:
+            :class:`OAuth2`
+        :param session:
+            The Box API session to wrap for authorization.
+        :type session:
+            :class:`Session`
+        """
+        super(AuthorizedSession, self).__init__(**kwargs)
+        self._oauth = oauth
+
+    def get_constructor_kwargs(self):
+        kwargs = super(AuthorizedSession, self).get_constructor_kwargs()
+        kwargs['oauth'] = self._oauth
+        return kwargs
+
+    def _renew_session(self, access_token_used):
+        """
+        Renews the session by refreshing the access token.
+
+        :param access_token_used:
+            The access token that's currently being used by the session, that needs to be refreshed.
+        :type access_token_used:
+            `unicode` or None
+        """
+        new_access_token, _ = self._oauth.refresh(access_token_used)
+        return new_access_token
+
+    def _get_retry_request_callable(self, network_response, attempt_number, request):
+        """
+        Get a callable that retries a request for certain types of failure.
+
+        For 401 Unauthorized responses, renew the session by refreshing the access token; then retry.
+
+        Otherwise, defer to baseclass implementation.
+
+        :param network_response:
+            The response from the Box API.
+        :type network_response:
+            :class:`NetworkResponse`
+        :param attempt_number:
+            How many attempts at this request have already been tried. Used for exponential backoff calculations.
+        :type attempt_number:
+            `int`
+        :param request:
+            The API request that could require retrying.
+        :type request:
+            :class:`BoxRequest`
+        :return:
+            Callable that, when called, will retry the request. Takes the same parameters as :meth:`_send_request`.
+        :rtype:
+            `callable`
+        """
+        code = network_response.status_code
+        if code == 401 and request.auto_session_renewal:
+            self._renew_session(network_response.access_token_used)
+            request.auto_session_renewal = False
+            return self._send_request
+        return super(AuthorizedSession, self)._get_retry_request_callable(
+            network_response,
+            attempt_number,
+            request,
+        )
 
     def _send_request(self, request, **kwargs):
         """
@@ -392,98 +540,6 @@ class BoxSession(object):
             access_token = self._renew_session(None)
             request.auto_session_renewal = False
         authorization_header = {'Authorization': 'Bearer {0}'.format(access_token)}
-        if request.headers is None:
-            request.headers = self._default_headers.copy()
         request.headers.update(authorization_header)
-
-        # Reset stream positions to what they were when the request was made so the same data is sent even if this
-        # is a retried attempt.
-        files, file_stream_positions = kwargs.get('files'), kwargs.pop('file_stream_positions')
-        request_kwargs = self._default_network_request_kwargs.copy()
-        request_kwargs.update(kwargs)
-        if files and file_stream_positions:
-            for name, position in file_stream_positions.items():
-                files[name][1].seek(position)
-            data = request_kwargs.pop('data', {})
-            multipart_stream = MultipartStream(data, files)
-            request_kwargs['data'] = multipart_stream
-            del request_kwargs['files']
-            request.headers['Content-Type'] = multipart_stream.content_type
-
-        # send the request
-        network_response = self._network_layer.request(
-            request.method,
-            request.url,
-            access_token=access_token,
-            headers=request.headers,
-            **request_kwargs
-        )
-
-        return network_response
-
-    def get(self, url, **kwargs):
-        """Make a GET request to the Box API.
-
-        :param url:
-            The URL for the request.
-        :type url:
-            `unicode`
-        """
-        return self.request('GET', url, **kwargs)
-
-    def post(self, url, **kwargs):
-        """Make a POST request to the Box API.
-
-        :param url:
-            The URL for the request.
-        :type url:
-            `unicode`
-        """
-        return self.request('POST', url, **kwargs)
-
-    def put(self, url, **kwargs):
-        """Make a PUT request to the Box API.
-
-        :param url:
-            The URL for the request.
-        :type url:
-            `unicode`
-        """
-        return self.request('PUT', url, **kwargs)
-
-    def delete(self, url, **kwargs):
-        """Make a DELETE request to the Box API.
-
-        :param url:
-            The URL for the request.
-        :type url:
-            `unicode`
-        """
-        if 'expect_json_response' not in kwargs:
-            kwargs['expect_json_response'] = False
-        return self.request('DELETE', url, **kwargs)
-
-    def options(self, url, **kwargs):
-        """Make an OPTIONS request to the Box API.
-
-        :param url:
-            The URL for the request.
-        :type url:
-            `unicode`
-        """
-        return self.request('OPTIONS', url, **kwargs)
-
-    def request(self, method, url, **kwargs):
-        """Make a request to the Box API.
-
-        :param method:
-            The HTTP verb for the request.
-        :type method:
-            `unicode`
-        :param url:
-            The URL for the request.
-        :type url:
-            `unicode`
-        """
-        response = self._prepare_and_send_request(method, url, **kwargs)
-        return self.box_response_constructor(response)
+        kwargs['access_token'] = access_token
+        return super(AuthorizedSession, self)._send_request(request, **kwargs)

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,13 @@ class PyTest(TestCommand):
 
 def main():
     base_dir = dirname(__file__)
-    install_requires = ['attrs>=16.0.0', 'requests>=2.4.3', 'six>=1.9.0', 'requests-toolbelt>=0.4.0']
+    install_requires = [
+        'attrs>=16.0.0',
+        'requests>=2.4.3',
+        'requests-toolbelt>=0.4.0',
+        'six>=1.9.0',
+        'wrapt>=1.10.1',
+    ]
     redis_requires = ['redis>=2.10.3']
     jwt_requires = ['pyjwt>=1.3.0', 'cryptography>=0.9.2']
     extra_requires = defaultdict(list)

--- a/test/integration/conftest.py
+++ b/test/integration/conftest.py
@@ -7,22 +7,24 @@ import pytest
 
 from boxsdk import Client
 from boxsdk.auth.oauth2 import OAuth2
-from test.integration.mock_network import MockNetwork
+from boxsdk.session.session import Session, AuthorizedSession
+
+from .mock_network import MockNetwork
 
 
 @pytest.fixture()
-def box_client(box_oauth, mock_box_network):
+def box_client(box_oauth, mock_box_session):
     # pylint:disable=redefined-outer-name
-    return Client(box_oauth, network_layer=mock_box_network)
+    return Client(box_oauth, session=mock_box_session)
 
 
 @pytest.fixture()
-def box_oauth(mock_box_network, client_id, client_secret, access_token, refresh_token):
+def box_oauth(unauthorized_session, client_id, client_secret, access_token, refresh_token):
     # pylint:disable=redefined-outer-name
     return OAuth2(
         client_id,
         client_secret,
-        network_layer=mock_box_network,
+        session=unauthorized_session,
         access_token=access_token,
         refresh_token=refresh_token,
     )
@@ -31,6 +33,16 @@ def box_oauth(mock_box_network, client_id, client_secret, access_token, refresh_
 @pytest.fixture()
 def mock_box_network():
     return MockNetwork()
+
+
+@pytest.fixture()
+def unauthorized_session(mock_box_network):
+    return Session(network_layer=mock_box_network)
+
+
+@pytest.fixture()
+def mock_box_session(mock_box_network, box_oauth):
+    return AuthorizedSession(box_oauth, network_layer=mock_box_network)
 
 
 @pytest.fixture

--- a/test/integration/test_retry_and_refresh.py
+++ b/test/integration/test_retry_and_refresh.py
@@ -29,7 +29,7 @@ def test_automatic_refresh(
             'POST',
             '{0}/token'.format(API.OAUTH2_API_URL),
             data=ANY,
-            headers={'content-type': 'application/x-www-form-urlencoded'},
+            headers={'content-type': 'application/x-www-form-urlencoded', 'User-Agent': ANY},
         ),
         call(
             'GET',

--- a/test/unit/auth/test_jwt_auth.py
+++ b/test/unit/auth/test_jwt_auth.py
@@ -134,7 +134,7 @@ def pass_private_key_by_path(request):
 
 @pytest.fixture
 def jwt_auth_init_mocks(
-        mock_network_layer,
+        mock_box_session,
         successful_token_response,
         jwt_algorithm,
         jwt_key_id,
@@ -158,7 +158,7 @@ def jwt_auth_init_mocks(
             'box_device_id': '0',
             'box_device_name': 'my_awesome_device',
         }
-        mock_network_layer.request.return_value = successful_token_response
+        mock_box_session.request.return_value = successful_token_response
         with patch('boxsdk.auth.jwt_auth.open', mock_open(read_data=rsa_private_key_bytes), create=True) as jwt_auth_open:
             with patch('cryptography.hazmat.primitives.serialization.load_pem_private_key') as load_pem_private_key:
                 oauth = JWTAuth(
@@ -167,7 +167,7 @@ def jwt_auth_init_mocks(
                     rsa_private_key_file_sys_path=(sentinel.rsa_path if pass_private_key_by_path else None),
                     rsa_private_key_data=(None if pass_private_key_by_path else rsa_private_key_bytes),
                     rsa_private_key_passphrase=rsa_passphrase,
-                    network_layer=mock_network_layer,
+                    session=mock_box_session,
                     box_device_name='my_awesome_device',
                     jwt_algorithm=jwt_algorithm,
                     jwt_key_id=jwt_key_id,
@@ -188,7 +188,7 @@ def jwt_auth_init_mocks(
                 yield oauth, assertion, fake_client_id, load_pem_private_key.return_value
 
         if assert_authed:
-            mock_network_layer.request.assert_called_once_with(
+            mock_box_session.request.assert_called_once_with(
                 'POST',
                 '{0}/token'.format(API.OAUTH2_API_URL),
                 data=data,

--- a/test/unit/auth/test_redis_managed_oauth2.py
+++ b/test/unit/auth/test_redis_managed_oauth2.py
@@ -47,7 +47,7 @@ def test_redis_managed_oauth2_gets_tokens_from_redis_during_refresh(access_token
 def test_redis_managed_oauth2_stores_tokens_to_redis_during_refresh(
         access_token,
         refresh_token,
-        mock_network_layer,
+        mock_box_session,
         successful_token_response,
 ):
     redis_server = Mock(redis_managed_oauth2.StrictRedis)
@@ -59,8 +59,8 @@ def test_redis_managed_oauth2_stores_tokens_to_redis_during_refresh(
             client_secret=None,
             unique_id=unique_id,
             redis_server=redis_server,
-            network_layer=mock_network_layer,
+            session=mock_box_session,
         )
-    mock_network_layer.request.return_value = successful_token_response
+    mock_box_session.request.return_value = successful_token_response
     oauth2.send_token_request({}, access_token=None, expect_refresh_token=True)
     redis_server.hmset.assert_called_once_with(unique_id, {'access': access_token, 'refresh': refresh_token})

--- a/test/unit/conftest.py
+++ b/test/unit/conftest.py
@@ -8,12 +8,11 @@ import json
 from mock import Mock, MagicMock
 import pytest
 
-from boxsdk.auth.oauth2 import DefaultNetwork
 from boxsdk.config import API, Client
 from boxsdk.network import default_network
-from boxsdk.network.default_network import DefaultNetworkResponse
+from boxsdk.network.default_network import DefaultNetworkResponse, DefaultNetwork
 from boxsdk.session.box_response import BoxResponse
-from boxsdk.session.box_session import BoxSession
+from boxsdk.session.session import Session
 from boxsdk.util.translator import Translator
 
 
@@ -47,24 +46,24 @@ def translator(default_translator):   # pylint:disable=unused-argument
 
 @pytest.fixture(scope='function')
 def mock_box_session(translator):
-    mock_session = MagicMock(BoxSession)
+    mock_session = MagicMock(Session)
     # pylint:disable=protected-access
     mock_session._api_config = mock_session.api_config = API()
     mock_session._client_config = mock_session.client_config = Client()
     # pylint:enable=protected-access
-    mock_session.get_url.side_effect = lambda *args, **kwargs: BoxSession.get_url(mock_session, *args, **kwargs)
+    mock_session.get_url.side_effect = lambda *args, **kwargs: Session.get_url(mock_session, *args, **kwargs)
     mock_session.translator = translator
     return mock_session
 
 
 @pytest.fixture()
 def mock_box_session_2():
-    mock_session = MagicMock(BoxSession)
+    mock_session = MagicMock(Session)
     # pylint:disable=protected-access
     mock_session._api_config = API()
     mock_session._client_config = Client()
     # pylint:enable=protected-access
-    mock_session.get_url.side_effect = lambda *args, **kwargs: BoxSession.get_url(mock_session, *args, **kwargs)
+    mock_session.get_url.side_effect = lambda *args, **kwargs: Session.get_url(mock_session, *args, **kwargs)
     return mock_session
 
 

--- a/test/unit/pagination/test_limit_offset_based_object_collection.py
+++ b/test/unit/pagination/test_limit_offset_based_object_collection.py
@@ -1,14 +1,16 @@
 # coding: utf-8
 
 from __future__ import unicode_literals, absolute_import
+
 import json
+
 from mock import Mock, PropertyMock
 import pytest
 
 from boxsdk.network.default_network import DefaultNetworkResponse
 from boxsdk.pagination.limit_offset_based_object_collection import LimitOffsetBasedObjectCollection
 from boxsdk.session.box_response import BoxResponse
-from boxsdk.session.box_session import BoxSession
+from boxsdk.session.session import Session
 from .box_object_collection_test_base import BoxObjectCollectionTestBase
 
 
@@ -37,7 +39,7 @@ class TestLimitOffsetBasedObjectCollection(BoxObjectCollectionTestBase):
     @pytest.fixture()
     def mock_session(self, translator, mock_items_response):
         """Baseclass override."""
-        mock_box_session = Mock(BoxSession)
+        mock_box_session = Mock(Session)
         type(mock_box_session).translator = PropertyMock(
             return_value=translator
         )

--- a/test/unit/pagination/test_marker_based_object_collection.py
+++ b/test/unit/pagination/test_marker_based_object_collection.py
@@ -8,7 +8,7 @@ import pytest
 from boxsdk.network.default_network import DefaultNetworkResponse
 from boxsdk.pagination.marker_based_object_collection import MarkerBasedObjectCollection
 from boxsdk.session.box_response import BoxResponse
-from boxsdk.session.box_session import BoxSession
+from boxsdk.session.session import Session
 from .box_object_collection_test_base import BoxObjectCollectionTestBase
 
 
@@ -59,7 +59,7 @@ class TestMarkerBasedObjectCollection(BoxObjectCollectionTestBase):
     @pytest.fixture()
     def mock_session(self, translator, mock_items_response):
         """Baseclass override."""
-        mock_box_session = Mock(BoxSession)
+        mock_box_session = Mock(Session)
         type(mock_box_session).translator = PropertyMock(return_value=translator)
 
         def mock_items_side_effect(_, params):

--- a/test/unit/pagination/test_page.py
+++ b/test/unit/pagination/test_page.py
@@ -9,7 +9,7 @@ from six.moves import range  # pylint:disable=redefined-builtin
 from boxsdk.object.file import File
 from boxsdk.object.folder import Folder
 from boxsdk.pagination.page import Page
-from boxsdk.session.box_session import BoxSession
+from boxsdk.session.session import Session
 from boxsdk.util.translator import Translator
 
 
@@ -20,7 +20,7 @@ def translator():
 
 @pytest.fixture()
 def mock_session(translator):
-    mock_box_session = Mock(BoxSession)
+    mock_box_session = Mock(Session)
     type(mock_box_session).translator = PropertyMock(
         return_value=translator
     )

--- a/test/unit/session/test_session.py
+++ b/test/unit/session/test_session.py
@@ -14,7 +14,7 @@ from boxsdk.config import API
 from boxsdk.exception import BoxAPIException
 from boxsdk.network.default_network import DefaultNetwork, DefaultNetworkResponse
 from boxsdk.session.box_response import BoxResponse
-from boxsdk.session.box_session import BoxSession, Translator
+from boxsdk.session.session import Session, Translator, AuthorizedSession
 
 
 @pytest.fixture(scope='function', params=[False, True])
@@ -42,17 +42,23 @@ def mock_network_layer():
 
 
 @pytest.fixture
+def unauthorized_session(mock_network_layer, translator):
+    # pylint:disable=redefined-outer-name
+    return Session(network_layer=mock_network_layer, translator=translator)
+
+
+@pytest.fixture
 def box_session(mock_oauth, mock_network_layer, translator):
     # pylint:disable=redefined-outer-name
-    return BoxSession(oauth=mock_oauth, network_layer=mock_network_layer, translator=translator)
+    return AuthorizedSession(oauth=mock_oauth, network_layer=mock_network_layer, translator=translator)
 
 
 @pytest.mark.parametrize('test_method', [
-    BoxSession.get,
-    BoxSession.post,
-    BoxSession.put,
-    BoxSession.delete,
-    BoxSession.options,
+    Session.get,
+    Session.post,
+    Session.put,
+    Session.delete,
+    Session.options,
 ])
 def test_box_session_handles_unauthorized_response(
         test_method,
@@ -84,11 +90,11 @@ def test_box_session_handles_unauthorized_response(
 
 
 @pytest.mark.parametrize('test_method', [
-    BoxSession.get,
-    BoxSession.post,
-    BoxSession.put,
-    BoxSession.delete,
-    BoxSession.options,
+    Session.get,
+    Session.post,
+    Session.put,
+    Session.delete,
+    Session.options,
 ])
 @pytest.mark.parametrize('initial_access_token', [None])
 def test_box_session_gets_access_token_before_request(
@@ -120,12 +126,12 @@ def test_box_session_gets_access_token_before_request(
 
 
 @pytest.mark.parametrize('test_method', [
-    BoxSession.get,
-    BoxSession.post,
-    BoxSession.put,
-    BoxSession.delete,
-    BoxSession.options,
-    partial(BoxSession.request, method='head'),
+    Session.get,
+    Session.post,
+    Session.put,
+    Session.delete,
+    Session.options,
+    partial(Session.request, method='head'),
 ])
 def test_box_session_retries_response_after_retry_after(
         test_method,
@@ -147,12 +153,12 @@ def test_box_session_retries_response_after_retry_after(
 
 
 @pytest.mark.parametrize('test_method', [
-    BoxSession.get,
-    BoxSession.post,
-    BoxSession.put,
-    BoxSession.delete,
-    BoxSession.options,
-    partial(BoxSession.request, method='head'),
+    Session.get,
+    Session.post,
+    Session.put,
+    Session.delete,
+    Session.options,
+    partial(Session.request, method='head'),
 ])
 def test_box_session_retries_request_after_server_error(
         test_method,


### PR DESCRIPTION
Previously, auth classes used the network layer directly, while all
other API calls used the session as a network abstraction. This
was not only confusing, but it robbed auth calls of all the session's
features, like automatic retry, user agent, custom headers, etc.

The reason for this was the SDK's architecture. Since the session
handles auth refresh, it needed an auth instance. This commit
refactors the session into unauthorized and authorized parts. Auth
calls now use the unauthorized session, and other API calls use
the authorized session.