### PR TITLE
Stop respecting the 'offset' value in HTTP response.

### DIFF
--- a/boxsdk/pagination/limit_offset_based_object_collection.py
+++ b/boxsdk/pagination/limit_offset_based_object_collection.py
@@ -43,17 +43,18 @@ class LimitOffsetBasedObjectCollection(BoxObjectCollection):
         """Baseclass override."""
         total_count = response_object['total_count']
 
-        # The API might use a lower limit than the client asked for, if the
-        # client asked for a limit above the maximum limit for that endpoint.
-        # The API is supposed to respond with the limit that it actually used.
-        # If that is given, then use that limit for the offset calculation, and
-        # also for the remainder of the paging.
-        #
-        # Similarly, the API reports the offset that it used. In theory, this
-        # should always be the same as what was requested. But just in case, do
-        # the same thing with offset.
         if 'limit' in response_object:
             self._limit, old_limit = int(response_object['limit']), self._limit
+
+            # The API might use a lower limit than the client asked for, if the
+            # client asked for a limit above the maximum limit for that endpoint.
+            # The API is supposed to respond with the limit that it actually used.
+            # If that is given, then use that limit for the offset calculation, and
+            # also for the remainder of the paging.
+
+            # Do not apply this same logic to "offset". Offset is not documented to be
+            # changed in the response, so respecting that value can lead to undefined
+            # behavior.
 
             # If the API erroneously sends a bad value for limit, we want to
             # avoid getting into an infinite chain of API calls. So abort with
@@ -62,8 +63,8 @@ class LimitOffsetBasedObjectCollection(BoxObjectCollection):
                 self._offset = total_count  # Disable additional paging.
                 raise RuntimeError('API returned limit={0}, cannot continue paging'.format(self._limit))
 
-        if 'offset' in response_object:
-            self._offset = int(response_object['offset'])
+        # de-none-ify the _offset value so that the arthimatic below works
+        self._offset = self._offset or 0
 
         if total_count >= self._offset + self._limit:
             self._offset += self._limit

--- a/test/unit/object/test_group.py
+++ b/test/unit/object/test_group.py
@@ -156,7 +156,7 @@ def test_get_memberships_with_hidden_results(test_group, mock_box_session, mock_
     mock_box_session.get.side_effect = mock_membership_responses(total, page_size, hidden_in_batch=hidden_in_batch)
 
     # Get all the members
-    all_members = test_group.get_memberships(0, page_size)
+    all_members = test_group.get_memberships(limit=page_size, offset=0)
 
     # Assert we got the expected number of membership instances
     count = 0

--- a/test/unit/pagination/test_limit_offset_based_object_collection.py
+++ b/test/unit/pagination/test_limit_offset_based_object_collection.py
@@ -55,6 +55,7 @@ class TestLimitOffsetBasedObjectCollection(BoxObjectCollectionTestBase):
     @pytest.fixture()
     def mock_session_with_bogus_limit(self, mock_session, mock_items_response):
         """Baseclass override."""
+        # pylint:disable=no-self-use
 
         def mock_items_side_effect(_, params):
             limit = 0
@@ -133,4 +134,3 @@ class TestLimitOffsetBasedObjectCollection(BoxObjectCollectionTestBase):
         )
         with pytest.raises(RuntimeError):
             object_collection.next()
-

--- a/test/unit/pagination/test_limit_offset_based_object_collection.py
+++ b/test/unit/pagination/test_limit_offset_based_object_collection.py
@@ -52,6 +52,18 @@ class TestLimitOffsetBasedObjectCollection(BoxObjectCollectionTestBase):
         mock_box_session.get.side_effect = mock_items_side_effect
         return mock_box_session
 
+    @pytest.fixture()
+    def mock_session_with_bogus_limit(self, mock_session, mock_items_response):
+        """Baseclass override."""
+
+        def mock_items_side_effect(_, params):
+            limit = 0
+            offset = params.get('offset', 0)
+            return mock_items_response(limit, offset)
+
+        mock_session.get.side_effect = mock_items_side_effect
+        return mock_session
+
     def _object_collection_instance(self, session, limit=None, return_full_pages=False, starting_pointer=None):
         """Baseclass override."""
         if starting_pointer is None:
@@ -107,3 +119,18 @@ class TestLimitOffsetBasedObjectCollection(BoxObjectCollectionTestBase):
         object_collection = self._object_collection_instance(mock_session, limit=(1 + self.DEFAULT_LIMIT))
         object_collection.next()
         assert object_collection._limit == self.DEFAULT_LIMIT   # pylint:disable=protected-access
+
+    def test_box_returning_bogus_limit_raises_runtime_error(self, mock_session_with_bogus_limit, entries):
+        """
+        Confirm that the SDK raises a RuntimeError is box.com happens to return a bogus `limit` in the response
+        """
+        starting_offset = len(entries) + 10
+        object_collection = self._object_collection_instance(
+            mock_session_with_bogus_limit,
+            limit=5,
+            return_full_pages=False,
+            starting_pointer=starting_offset
+        )
+        with pytest.raises(RuntimeError):
+            object_collection.next()
+


### PR DESCRIPTION
Paging APIs return total_count, limit, and offset value. The
V2 API docs talk about how to respect the total_count and
limit fields. But do not state that 'offset' should be interpreted.
So remove the ode that was respecting this value as it can lead
to undefined behavior if it starts to change.

Also add test coverage for existing logic in the paging code.

And fix a broken test in test_group where it was passing params
in the wrong order to Group.get_memberships(). A strange
coincidence that these tests were ever passing???