### PR TITLE
Add quotes around JWT install package name to avoid package not found…

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -119,7 +119,7 @@ Authenticating with a JWT requires some extra dependencies. To get them, simply
 
 .. code-block:: console
 
-    pip install boxsdk[jwt]
+    pip install "boxsdk[jwt]"
 
 Instead of instantiating your ``Client`` with an instance of ``OAuth2``,
 instead use an instance of ``JWTAuth``.


### PR DESCRIPTION
Related error description and resolution: https://stackoverflow.com/questions/42915098/pip-install-boxsdk-with-jwt-oath-not-functioning-as-expected