### PR TITLE
Upgrading request-toolbelt to accept 0.9.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ def main():
     install_requires = [
         'attrs>=17.3.0',
         'requests>=2.4.3',
-        'requests-toolbelt>=0.4.0, <=0.9.1',
+        'requests-toolbelt>=0.4.0, <1.0.0',
         'six>=1.9.0',
         'wrapt>=1.10.1',
     ]

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ def main():
     install_requires = [
         'attrs>=17.3.0',
         'requests>=2.4.3',
-        'requests-toolbelt>=0.4.0, <0.9.0',
+        'requests-toolbelt>=0.4.0, <=0.9.1',
         'six>=1.9.0',
         'wrapt>=1.10.1',
     ]


### PR DESCRIPTION
It looks like in the changelog for request-toolbelt 0.9.1 there was a bug fix for importing pyOpenSSL.

This previously was already broken so it should not affect the SDK.

#408 