### PR TITLE
Locking down xdist to any version prior to 1.28.0 because of pytest 4.4.0 dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -96,7 +96,7 @@ def main():
         'pylint',
         'sqlalchemy',
         'tox',
-        'pytest>=2.8.3, <4.0.0',
+        'pytest>=2.8.3, <=4.4.0',
         'pytest-cov',
         'pytest-xdist',
         'python-coveralls',

--- a/setup.py
+++ b/setup.py
@@ -96,9 +96,9 @@ def main():
         'pylint',
         'sqlalchemy',
         'tox',
-        'pytest>=2.8.3, <=4.4.0',
+        'pytest>=2.8.3, <4.0.0',
         'pytest-cov',
-        'pytest-xdist',
+        'pytest-xdist<1.28.0',
         'python-coveralls',
         'pytz',
     ]


### PR DESCRIPTION
Context:

Tests were failing for all python builds on master because xdist failed to load.

Reason being - from xdist Changelog:

#426: pytest-xdist now uses the new pytest_report_to_serializable and pytest_report_from_serializable hooks from pytest 4.4 (still experimental). This will make report serialization more reliable and extensible.

This also means that pytest-xdist now requires pytest>=4.4.

Python SDK uses pytest version before 4.0.0. Upgrading to 4.4.0 seems to cause some issues and will require refactoring of certain tests.

In the interim looks like locking down xdist to anything prior to 1.28.0 will suffice.