### PR TITLE
Tag code samples for usage in developer docs

### DIFF
--- a/docs/search.md
+++ b/docs/search.md
@@ -10,6 +10,7 @@ Search for Content
 To get a list of items matching a serch query, call [`search.query(query, limit=None, offset=0, **kwargs)`][query] will return an `Iterable` that allows you 
 to iterate over the [`Item`][item_class] objects in the collection.
 
+<!-- sample get_search -->
 ```python
 items = client.search().query(query='TEST QUERY', limit=100, file_extensions=['pdf', 'doc'])
 for item in items:

--- a/docs/usage/authentication.md
+++ b/docs/usage/authentication.md
@@ -190,6 +190,7 @@ The first step in the process is to redirect the user to the Box Authorize URL, 
 (along with a CSRF token) by calling [`oauth.get_authorization_url(redirect_url)`][get_authorization_url] with
 your application's redirect URL.
 
+<!-- sample get_authorize -->
 ```python
 from boxsdk import OAuth2
 
@@ -218,6 +219,7 @@ you will be able to exchange it for an access token and refresh token.
 The SDK handles all the work for you; all you need to do is call [`oauth.authenticate(auth_code)`][authenticate] with
 the auth code pulled from the query parameters of the incoming URL:
 
+<!-- sample get_authorize -->
 ```python
 from boxsdk import Client
 
@@ -323,6 +325,7 @@ Revoking Tokens
 To revoke the tokens contained in an [`OAuth2`][oauth2_class] instance, removing the ability to call the Box API,
 call [`oauth.revoke()`][revoke].
 
+<!-- sample post_oauth2_revoke -->
 ```python
 oauth.revoke()
 ```

--- a/docs/usage/authentication.md
+++ b/docs/usage/authentication.md
@@ -219,7 +219,7 @@ you will be able to exchange it for an access token and refresh token.
 The SDK handles all the work for you; all you need to do is call [`oauth.authenticate(auth_code)`][authenticate] with
 the auth code pulled from the query parameters of the incoming URL:
 
-<!-- sample get_authorize -->
+<!-- sample post_oauth2_token -->
 ```python
 from boxsdk import Client
 

--- a/docs/usage/collaboration.md
+++ b/docs/usage/collaboration.md
@@ -27,6 +27,7 @@ You can add a collaboration on a folder or a file by calling
 `role` parameter determines what permissions the collaborator will have on the folder.  This method returns a
 [`Collaboration`][collaboration_class] object representing the new collaboration on the item.
 
+<!-- sample post_collaborations -->
 ```python
 from boxsdk.object.collaboration import CollaborationRole
 
@@ -59,6 +60,7 @@ Edit a Collaboration
 A collaboration can be edited by calling [`collaboration.update_info(role, status=None)`][update_info].  This method
 returns an updated [`Collaboration`][collaboration_class] object, leaving the original unmodified.
 
+<!-- sample put_collaborations_id -->
 ```python
 from boxsdk.object.collaboration import CollaborationRole, CollaborationStatus
 
@@ -75,6 +77,7 @@ A collaboration can be removed by calling [`collaboration.delete()`][delete].  T
 group associated with the collaboration to lose access to the item.  This method returns `True` to indicate that removal
 succeeded.
 
+<!-- sample delete_collaborations_id -->
 ```python
 collaboration_id = '1111'
 client.collaboration(collaboration_id).delete()
@@ -88,6 +91,7 @@ Get a Collaboration's Information
 To get information about a specific collaboration, call [`collaboration.get()`][get].  This method returns a new
 [`Collaboration`][collaboration_class] with fields populated by data from the API.
 
+<!-- sample get_collaborations_id -->
 ```python
 collaboration = client.collaboration(collab_id='12345').get()
 ```
@@ -102,6 +106,7 @@ To retrieve all collaborations on a specified [`Folder`][folder_class] or [`File
 `BoxObjectCollection` that you can use to iterate over all
 [`Collaboration`][collaboration_class] objects in the collection.
 
+<!-- sample get_folders_id_collaborations -->
 ```python
 collaborations = client.folder(folder_id='22222').get_collaborations()
 for collab in collaborations:
@@ -109,6 +114,7 @@ for collab in collaborations:
     print('{0} {1} is collaborated on the folder'.format(target.type.capitalize(), target.name))
 ```
 
+<!-- sample get_files_id_collaborations -->
 ```python
 collaborations = client.file(file_id='11111').get_collaborations()
 for collab in collaborations
@@ -128,6 +134,7 @@ To retrieve all pending collaborations for the current user, call
 accept or reject these collaborations.  This method returns a `BoxObjectCollection` that you
 can use to iterate over all pending [`Collaboration`][collaboration_class] objects in the collection.
 
+<!-- sample get_collaborations -->
 ```python
 pending_collaborations = client.get_pending_collaborations()
 for pending_collaboration in pending_collaborations:
@@ -143,6 +150,7 @@ To accept or reject a pending collaboration, call [`collaboration.accept()`][acc
 [`collaboration.reject()`][reject].  These methods both return the updated [`Collaboration`][collaboration_class]
 object, leaving the original unmodified.
 
+<!-- sample put_collaborations_id -->
 ```python
 accepted_collab = client.collaboration(collab_id='12345').accept()
 

--- a/docs/usage/collaboration_whitelist.md
+++ b/docs/usage/collaboration_whitelist.md
@@ -30,6 +30,7 @@ To retrieve a list of collaboration whitelist entries, call
 `BoxObjectCollection` which can iterate over the [`CollaborationWhitelistEntry`][entry_class]
 objects in the collection.
 
+<!-- sample get_collaboration_whitelist_entries -->
 ```python
 whitelist_entries = client.collaboration_whitelist().get_entries()
 for entry in whitelist_entries:
@@ -46,6 +47,7 @@ Get Information for Collaboration Whitelist Entry
 To get information about a collaboration whitelist entry, use [`collaboration_whitelist_entry.get(fields=None)`][get].
 This method returns a [`CollaborationWhitelistEntry`][entry_class] object with fields populated by data form the API.
 
+<!-- sample get_collaboration_whitelist_entries_id -->
 ```python
 whitelist_entry = client.collaboration_whitelist_entry(entry_id='11111').get()
 ```
@@ -63,6 +65,7 @@ You can determine the direction of the whitelist by passing in 'outbound', 'inbo
 is defined as a user in your enterprise collaborating on content owned by someone outside your enterprise. Inbound
 collaboration is defined as a user outside of your enterprise collaborating on content owned by your enterprise.
 
+<!-- sample post_collaboration_whitelist_entries -->
 ```python
 from boxsdk.object.collaboration_whitelist import WhitelistDirection
 domain = 'example.com'
@@ -78,6 +81,7 @@ To remove a collaboration whitelisted domain, call [`collaboration_whitelist_ent
 the domain from the whitelist, restricting collaboration to and from users in that domain.  This method returns `True`
 to indicate that deletion was successful.
 
+<!-- sample delete_collaboration_whitelist_entries_id -->
 ```python
 client.collaboration_whitelist_entry(entry_id='11111').delete()
 ```
@@ -92,6 +96,7 @@ To get all exempt users from the collaboration whitelist, call
 a `BoxObjectCollection` that allows you to iterate over each
 [`CollaborationWhitelistExemptTarget`][exemption_class] in the collection.
 
+<!-- sample get_collaboration_whitelist_excempt_targets -->
 ```python
 exemptions = client.collaboration_whitelist().get_exemptions()
 for exemption in exemptions:
@@ -107,6 +112,7 @@ Get Exempt User Information
 To get information about an exempted user, call [`collaboration_whitelist_exempt_target.get(fields=None)`][get].  This
 method will return a [`CollaborationWhitelistExemptTarget][exemption_class] with fields populated by data from the API.
 
+<!-- sample get_collaboration_whitelist_excempt_targets_id -->
 ```python
 exemption_id = '11111'
 exemption = client.collaboration_whitelist_exempt_target(exemption_id).get()
@@ -120,6 +126,7 @@ with the [`User`][user_class] to exempt from the whitelist.  This user will no l
 whitelist, and will be permitted to collaborate with users from any other domain.  This method returns a
 [`CollaborationWhitelistExemptTarget`][exemption_class] object representing the exempted user.
 
+<!-- sample post_collaboration_whitelist_excempt_targets -->
 ```python
 user = client.user(user_id='11111')
 exemption = client.collaboration_whitelist().add_exemption(user)
@@ -135,6 +142,7 @@ To remove a user exemption from the collaboration whitelist, call
 [`collaboration_whitelist_exempt_target.delete()`][delete].  This will remove the exemption and make the user subject to
 the collaboration whitelist again.  This method returns `True` to indicate that deletion was successful.
 
+<!-- sample delete_collaboration_whitelist_excempt_targets_id -->
 ```python
 client.collaboration_whitelist_exempt_target(exemption_id='22222').delete()
 ```

--- a/docs/usage/collaboration_whitelist.md
+++ b/docs/usage/collaboration_whitelist.md
@@ -96,7 +96,7 @@ To get all exempt users from the collaboration whitelist, call
 a `BoxObjectCollection` that allows you to iterate over each
 [`CollaborationWhitelistExemptTarget`][exemption_class] in the collection.
 
-<!-- sample get_collaboration_whitelist_excempt_targets -->
+<!-- sample get_collaboration_whitelist_exempt_targets -->
 ```python
 exemptions = client.collaboration_whitelist().get_exemptions()
 for exemption in exemptions:
@@ -112,7 +112,7 @@ Get Exempt User Information
 To get information about an exempted user, call [`collaboration_whitelist_exempt_target.get(fields=None)`][get].  This
 method will return a [`CollaborationWhitelistExemptTarget][exemption_class] with fields populated by data from the API.
 
-<!-- sample get_collaboration_whitelist_excempt_targets_id -->
+<!-- sample get_collaboration_whitelist_exempt_targets_id -->
 ```python
 exemption_id = '11111'
 exemption = client.collaboration_whitelist_exempt_target(exemption_id).get()
@@ -126,7 +126,7 @@ with the [`User`][user_class] to exempt from the whitelist.  This user will no l
 whitelist, and will be permitted to collaborate with users from any other domain.  This method returns a
 [`CollaborationWhitelistExemptTarget`][exemption_class] object representing the exempted user.
 
-<!-- sample post_collaboration_whitelist_excempt_targets -->
+<!-- sample post_collaboration_whitelist_exempt_targets -->
 ```python
 user = client.user(user_id='11111')
 exemption = client.collaboration_whitelist().add_exemption(user)
@@ -142,7 +142,7 @@ To remove a user exemption from the collaboration whitelist, call
 [`collaboration_whitelist_exempt_target.delete()`][delete].  This will remove the exemption and make the user subject to
 the collaboration whitelist again.  This method returns `True` to indicate that deletion was successful.
 
-<!-- sample delete_collaboration_whitelist_excempt_targets_id -->
+<!-- sample delete_collaboration_whitelist_exempt_targets_id -->
 ```python
 client.collaboration_whitelist_exempt_target(exemption_id='22222').delete()
 ```

--- a/docs/usage/collections.md
+++ b/docs/usage/collections.md
@@ -21,6 +21,7 @@ To get all collections belonging to a user, call [`client.collections(limit=None
 This method returns a `BoxObjectCollection` that you can use to iterate over all the
 [`Collection`][collection_class] objects in the set.
 
+<!-- sample get_collections -->
 ```python
 collections = client.collections()
 for collection in collections:
@@ -38,6 +39,7 @@ To retrieve a list of items contained in a collection, call
 `BoxObjectCollection` that you can use to iterate over all the [`Item`][item_class] objects in
 the collection.
 
+<!-- sample get_collections_id_items -->
 ```python
 items = client.collection(collection_id='12345').get_items()
 for item in items:

--- a/docs/usage/comments.md
+++ b/docs/usage/comments.md
@@ -24,6 +24,7 @@ To get a specific comment object, first call `[client.comment(comment_id)`][comm
 comment.  The latter method returns a new [`Comment`][comment_class] object with fields populated by data from the API,
 leaving the original unmodified.
 
+<!-- sample get_comment_id -->
 ```python
 comment = client.comment(comment_id='55555').get()
 print('The comment says "{0}"'.format(comment.message))
@@ -40,6 +41,7 @@ To retrieve the comment left on a file, call [`file.get_comments(limit=None, off
 This method returns a `BoxObjectCollection` that you can use to iterate over all the
 [`Comment`][comment_class] objects in the set.
 
+<!-- sample get_files_id_comments -->
 ```python
 comments = client.file(file_id='11111').get_comments()
 for comment in comments:
@@ -56,6 +58,7 @@ You can at-mention other users by adding special tags within the message, in the
 example, to at-mention John Doe, whose user ID is `"33333"`: `@[33333:John Doe]`.  This method returns a
 [`Comment`][comment_class] object representing the newly-created comment.
 
+<!-- sample post_comments -->
 ```python
 comment = client.file(file_id='11111').add_comment('Hey @[44444:boss], when should I have this done by?')
 ```
@@ -84,6 +87,7 @@ You can at-mention other users by adding special tags within the message, in the
 example, to at-mention John Doe, whose user ID is `"33333"`: `@[33333:John Doe]`.  This method returns an updated
 [`Comment`][comment_class] object, leaving the original unmodified.
 
+<!-- sample put_comments_id -->
 ```python
 edited_comment = client.comment(comment_id='98765').edit('If possible, please finish this by Friday!')
 ```
@@ -96,6 +100,7 @@ Delete a Comment
 To delete a comment, call [`comment.delete()`][delete].  This will remove the comment from the file.  This method
 returns `True` to indicate that the deletion succeeded.
 
+<!-- sample delete_comments_id -->
 ```python
 client.comment(comment_id='12345').delete()
 ```

--- a/docs/usage/device_pin.md
+++ b/docs/usage/device_pin.md
@@ -22,6 +22,7 @@ To retrieve all device pins for an enterprise, call
 If an `enterprise` is not specified, this defaults to the current enterprise.  This method returns a
 `BoxObjectCollection` that allows you to iterate over the [`DevicePinner`][device_pin_class] objects in the collection.
 
+<!-- sample get_enterprises_id_device_pinners -->
 ```python
 device_pins = client.device_pinners()
 for pin in device_pins:
@@ -37,6 +38,7 @@ Get Device Pin Information
 To get information about a specific device pin, call [`device_pinner.get(fields=None)`][get].  This method returns a new
 [`DevicePinner`][device_pin_class] object with fields populated by data from the API.
 
+<!-- sample get_device_pinners_id -->
 ```python
 device_pin_id = '1111'
 device_pin = client.device_pinner(device_pin_id).get()
@@ -51,6 +53,7 @@ Delete Device Pin
 To delete a specific device pin, call [`device_pinner.delete()`][delete].  This method returns `True` to indicate that
 the deletion was successful.
 
+<!-- sample delete_device_pinners_id -->
 ```python
 device_pin_id = '1111'
 client.device_pin(device_pin_id).delete()

--- a/docs/usage/events.md
+++ b/docs/usage/events.md
@@ -32,6 +32,7 @@ To automatically receive events as they happen, call
 the results.  By default, this will start listening for events from the current time onward; to get all available events,
 pass a `stream_position` of `0`.  The generator yields [`Event`][event_class] objects representing each event.
 
+<!-- sample options_events -->
 ```python
 events = client.events().generate_events_with_long_polling()
 for event in events:
@@ -62,6 +63,7 @@ will fetch the first available events chronologically; you can pass a specific `
 particular time.  This method returns a `dict` with the relevant [`Event`][event_class] objects in a `list` under the
 `entries` key and the next stream position value under the `next_stream_position` key.
 
+<!-- sample get_events -->
 ```python
 stream_position = 0
 events = client.events().get_events(stream_position=stream_position)

--- a/docs/usage/files.md
+++ b/docs/usage/files.md
@@ -56,6 +56,7 @@ This method returns a new [`File`][file_class] object populated with the informa
 
 You can specify an `Iterable` of fields to retrieve from the API in the `fields` parameter.
 
+<!-- sample get_file_id -->
 ```python
 file_id = '11111'
 file_info = client.file(file_id).get()
@@ -72,6 +73,7 @@ To update fields on the [`File`][file_class] object, call [`file.update_info(dat
 fields to update.  This method returns the updated [`File`][file_class] object, leaving the original it was called on
 unmodified.
 
+<!-- sample put_file_id -->
 ```python
 file_id = '11111'
 updated_file = client.file(file_id).update_info({'description': 'My file'})
@@ -88,6 +90,7 @@ parameter — the lower and upper bounds you wish to download.
 
 To get the entire contents of the file as `bytes`, call [`file.content(file_version=None, byte_range=None)`][content].
 
+<!-- sample get_file_id_content -->
 ```python
 file_id = '11111'
 
@@ -145,6 +148,7 @@ on the [`Folder`][folder_class] you want to upload the file into.  By default, t
 same file name as the one on disk; you can override this by passing a different name in the `file_name` parameter. You can, optionally, also choose to set a file description upon upload by using the `file_description` parameter.
 This method returns a [`File`][file_class] object representing the newly-uploaded file.
 
+<!-- sample post_files_content -->
 ```python
 folder_id = '22222'
 new_file = client.folder(folder_id).upload('/home/me/document.pdf')
@@ -318,6 +322,7 @@ To create an upload session for uploading a large version, call
 uploaded.  You can optionally specify a new `file_name` to rename the file on upload.  This method returns an
 [`UploadSession`][upload_session_class] object representing the created upload session.
 
+<!-- sample post_files_upload_sessions -->
 ```python
 file_size = 26000000
 upload_session = client.file('11111').create_upload_session(file_size)
@@ -334,6 +339,7 @@ To create an upload session for uploading a new large file, call
 to be uploaded.  This method returns an [`UploadSession`][upload_session_class] object representing the created upload
 session.
 
+<!-- sample post_files_id_upload_sessions -->
 ```python
 file_size = 26000000
 file_name = 'test_file.pdf'
@@ -354,6 +360,7 @@ records should be kept for the commit operation.
 > __Note:__ The number of bytes uploaded for each part must be exactly `upload_sesion.part_size`, except for the last
 > part (which just includes however many bytes are left in the file).
 
+<!-- sample put_files_upload_sessions_id -->
 ```python
 upload_session = client.upload_session('11493C07ED3EABB6E59874D3A1EF3581')
 offset = upload_session.part_size * 3
@@ -373,6 +380,7 @@ entire file.  For best consistency guarantees, you should also pass an `Iterable
 parameter; otherwise, the list of parts will be retrieved from the API.  You may also pass a `dict` of `file_attributes`
 to set on the new file.
 
+<!-- sample post_files_upload_sessions_id_commit -->
 ```python
 import hashlib
 
@@ -395,6 +403,7 @@ print('Successfully uploaded file {0} with description {1}'.format(uploaded_file
 To abort a chunked upload and lose all uploaded file parts, call [`upload_session.abort()`][abort].  This method returns
 `True` to indicate that the deletion succeeded.
 
+<!-- sample delete_files_upload_sessions_id -->
 ```python
 client.upload_session('11493C07ED3EABB6E59874D3A1EF3581').abort()
 print('Upload was successfully canceled')
@@ -407,6 +416,7 @@ print('Upload was successfully canceled')
 To return the list of parts uploaded so far, call [`upload_session.get_parts(limit=None, offset=None)`][get_parts].
 This method returns a `BoxObjectCollection` that allows you to iterate over the part `dict`s in the collection.
 
+<!-- sample get_files_upload_sessions_id_parts -->
 ```python
 parts = client.upload_session('11493C07ED3EABB6E59874D3A1EF3581').get_parts()
 for part in parts:
@@ -443,6 +453,7 @@ A file can be copied to a new folder by calling [`file.copy(parent_folder, name=
 folder and an optional new name for the file in case there is a name conflict in the destination folder.  This method
 returns a [`File`][file_class] object representing the copy of the file in the destination folder.
 
+<!-- sample post_files_id_copy -->
 ```python
 file_id = '11111'
 destination_folder_id = '44444'
@@ -463,6 +474,7 @@ Calling the [`file.delete()`][delete] method will delete the file.  Depending on
 the file to the user's trash or permanently delete the file.  This method returns `True` to signify that the deletion
 was successful.
 
+<!-- sample delete_files_id -->
 ```python
 client.file(file_id='11111').delete()
 ```
@@ -477,6 +489,7 @@ Previous versions of a file can be retrieved with the
 a [`BoxObjectCollection`][box_object_collection] that can iterate over the [`FileVersion`][file_version_class] objects
 in the collection.
 
+<!-- sample get_files_id_versions -->
 ```python
 file_id = '11111'
 
@@ -498,6 +511,7 @@ To upload a new file version from a path on disk, call the
 [`file.update_contents(file_path, etag=None, preflight_check=False, preflight_expected_size=0)`][update_contents]
 method.  This method returns a [`File`][file_class] object representing the updated file.
 
+<!-- sample post_files_id_content -->
 ```python
 file_id = '11111'
 file_path = '/path/to/file.pdf'
@@ -530,6 +544,7 @@ method to become the current version of the file with the [`FileVersion`][file_v
 copy of the old file version and puts it on the top of the versions stack.  This method returns the new copy
 [`FileVersion`][file_version_class] object.
 
+<!-- sample post_files_id_versions_current -->
 ```python
 file_id = '11111'
 file_version_id = '12345'
@@ -548,6 +563,7 @@ Delete a Previous Version of a File
 A version of a file can be deleted and moved to the trash by calling
 [`file.delete_version(file_version, etag=None)`][delete_version] with the [`FileVersion`] to delete.
 
+<!-- sample delete_files_id_versions_id -->
 ```python
 file_id = '11111'
 version_id = '12345'
@@ -663,6 +679,7 @@ A thumbnail for a file can be retrieved by calling
 [`file.get_thumbnail(extension='png', min_width=None, min_height=None, max_width=None, max_height=None)`][get_thumbnail].
 This method returns the `bytes` of the thumbnail image.
 
+<!-- sample get_files_id_thumbnail_id -->
 ```python
 file_id = '11111'
 
@@ -698,6 +715,7 @@ instance.
 Note: This method will only succeed if the provided metadata template is not currently applied to the file, otherwise it will 
 fail with a Conflict error.
 
+<!-- sample post_files_id_metadata_id_id -->
 ```python
 metadata = {
     'foo': 'bar',
@@ -720,6 +738,7 @@ Note: This method will only succeed if the provided metadata template has alread
 have existing metadata, this method will fail with a Not Found error. This is useful you know the file will already have metadata applied,
 since it will save an API call compared to `set()`.
 
+<!-- sample put_files_id_metadata_id_id -->
 ```python
 file_obj = client.file(file_id='11111')
 file_metadata = file_obj.metadata(scope='enterprise', template='myMetadata')
@@ -748,6 +767,7 @@ To retrieve the metadata instance on a file for a specific metadata template, fi
 metadata template to retrieve, then call [`metadata.get()`][metadata_get] to retrieve the metadata values attached to
 the file.  This method returns a `dict` containing the applied metadata instance.
 
+<!-- sample get_files_id_metadata_id_id -->
 ```python
 metadata = client.file(file_id='11111').metadata(scope='enterprise', template='myMetadata').get()
 print('Got metadata instance {0}'.format(metadata['$id']))
@@ -763,6 +783,7 @@ To remove a metadata instance from a file, call
 metadata template to remove, then call [`metadata.delete()`][metadata_delete] to remove the metadata from the file.
 This method returns `True` to indicate that the removal succeeded.
 
+<!-- sample delete_files_id_metadata_id_id -->
 ```python
 client.file(file_id='11111').metadata(scope='enterprise', template='myMetadata').delete()
 ```
@@ -777,6 +798,7 @@ To retrieve all metadata attached to a file, call [`file.get_all_metadata()`][ge
 instance attached to the
 file.
 
+<!-- sample get_files_id_metadata -->
 ```python
 file_metadata = client.file(file_id='11111').get_all_metadata()
 for instance in file_metadata:

--- a/docs/usage/files.md
+++ b/docs/usage/files.md
@@ -56,7 +56,7 @@ This method returns a new [`File`][file_class] object populated with the informa
 
 You can specify an `Iterable` of fields to retrieve from the API in the `fields` parameter.
 
-<!-- sample get_file_id -->
+<!-- sample get_files_id -->
 ```python
 file_id = '11111'
 file_info = client.file(file_id).get()
@@ -73,7 +73,7 @@ To update fields on the [`File`][file_class] object, call [`file.update_info(dat
 fields to update.  This method returns the updated [`File`][file_class] object, leaving the original it was called on
 unmodified.
 
-<!-- sample put_file_id -->
+<!-- sample put_files_id -->
 ```python
 file_id = '11111'
 updated_file = client.file(file_id).update_info({'description': 'My file'})
@@ -90,7 +90,7 @@ parameter — the lower and upper bounds you wish to download.
 
 To get the entire contents of the file as `bytes`, call [`file.content(file_version=None, byte_range=None)`][content].
 
-<!-- sample get_file_id_content -->
+<!-- sample get_files_id_content -->
 ```python
 file_id = '11111'
 

--- a/docs/usage/folders.md
+++ b/docs/usage/folders.md
@@ -40,6 +40,7 @@ the original object unmodified.
 You can pass a list of `fields` to retrieve from the API in order to filter to just the necessary fields or add
 ones not returned by default.
 
+<!-- sample get_folders_id -->
 ```python
 folder = client.folder(folder_id='22222').get()
 print('Folder "{0}" has {1} items in it'.format(folder.name, folder.item_collection.total_count))
@@ -69,6 +70,7 @@ To retrieve the items in a folder, call
 This method returns a `BoxObjectCollection` that allows you to iterate over all the [`Item`][item_class] objects in
 the collection.
 
+<!-- sample get_folders_id_items -->
 ```python
 items = client.folder(folder_id='22222').get_items()
 for item in items:
@@ -85,6 +87,7 @@ To update a folder's information, call [`folder.update_info(data, etag=None)`][u
 to update on the folder.  This method returns a new updated [`Folder`][folder_class] object, leaving the original
 object unmodified.
 
+<!-- sample put_folders_id -->
 ```python
 updated_folder = client.folder(folder_id='22222').update_info({
     'name': '[ARCHIVED] Planning documents',
@@ -102,6 +105,7 @@ A folder can be created by calling [`folder.create_subfolder(name)`][create_subf
 name of the subfolder to be created.  This method returns a new [`Folder`][folder_class] representing the created
 subfolder.
 
+<!-- sample post_folders -->
 ```python
 subfolder = client.folder('0').create_subfolder('My Stuff')
 print('Created subfolder with ID {0}'.format(subfolder.id))
@@ -116,6 +120,7 @@ A folder can be copied into a new parent folder by calling [`folder.copy(parent_
 destination folder and an optional new name for the file in case there is a name conflict in the destination folder.
 This method returns a new [`Folder`][folder_class] object representing the copy of the folder in the destination folder.
 
+<!-- sample post_folders_id_copy -->
 ```python
 folder_id = '22222'
 destination_folder_id = '44444'
@@ -160,6 +165,7 @@ settings, this will either move the folder to the user's trash or permanently de
 By default, the method will delete the folder and all of its contents; to fail the deletion if the folder is not empty,
 set the `recursive` parameter to `False`.
 
+<!-- sample delete_folders_id -->
 ```python
 client.folder(folder_id='22222').delete()
 ```
@@ -208,6 +214,7 @@ metadata instance.
 Note: This method will only succeed if the provided metadata template is not currently applied to the folder, otherwise it will 
 fail with a Conflict error.
 
+<!-- sample post_folders_id_metadata_id_id -->
 ```python
 metadata = {
     'foo': 'bar',
@@ -230,6 +237,7 @@ Note: This method will only succeed if the provided metadata template has alread
 have existing metadata, this method will fail with a Not Found error. This is useful you know the file will already have metadata applied,
 since it will save an API call compared to `set()`.
 
+<!-- sample put_folders_id_metadata_id_id -->
 ```python
 folder = client.folder(folder_id='22222')
 folder_metadata = folder.metadata(scope='enterprise', template='myMetadata')
@@ -258,6 +266,7 @@ To retrieve the metadata instance on a folder for a specific metadata template, 
 the metadata template to retrieve, then call [`metadata.get()`][metadata_get] to retrieve the metadata values attached
 to the folder.  This method returns a `dict` containing the applied metadata instance.
 
+<!-- sample get_folders_id_metadata_id_id -->
 ```python
 metadata = client.folder(folder_id='22222').metadata(scope='enterprise', template='myMetadata').get()
 print('Got metadata instance {0}'.format(metadata['$id']))
@@ -273,6 +282,7 @@ To remove a metadata instance from a folder, call
 metadata template to remove, then call [`metadata.delete()`][metadata_delete] to remove the metadata from the folder.
 This method returns `True` to indicate that the removal succeeded.
 
+<!-- sample delete_folders_id_metadata_id_id -->
 ```python
 client.folder(folder_id='11111').metadata(scope='enterprise', template='myMetadata').delete()
 ```
@@ -286,6 +296,7 @@ To retrieve all metadata attached to a folder, call [`folder.get_all_metadata()`
 returns a [`BoxObjectCollection`][box_object_collection] that can be used to iterate over the `dict`s representing each
 metadata instance attached to the folder.
 
+<!-- sample get_folders_id_metadata -->
 ```python
 folder_metadata = client.folder(folder_id='22222').get_all_metadata()
 for instance in folder_metadata:

--- a/docs/usage/group.md
+++ b/docs/usage/group.md
@@ -28,6 +28,7 @@ Calling [`client.get_groups(name=None, limit=None, offset=None, fields=None)`][g
 `BoxObjectCollection` that allows you to iterate over the [`Group`][group_class] objects representing groups in the
 enterprise.
 
+<!-- sample get_groups -->
 ```python
 groups = client.get_groups()
 for group in groups:
@@ -56,6 +57,7 @@ returns a [`Group`][group_class] object representing the created group.
 You can read more about the optional parameters in the
 [Create Group API documentation](https://developer.box.com/v2.0/reference#create-a-group).
 
+<!-- sample post_groups -->
 ```python
 created_group = client.create_group('Example Group')
 print('Created group with ID {0}'.format(created_group.id))
@@ -71,6 +73,7 @@ To retrieve information about a group, first call [`client.group(group_id)`][gro
 method returns a new [`Group`][group_class] object with fields populated by data form the API, leaving the original
 object unmodified.
 
+<!-- sample get_groups_id -->
 ```python
 group = client.group(group_id='11111').get()
 print('Got group {0}'.format(group.name))
@@ -94,6 +97,7 @@ Update a Group
 To update a group, call [`group.update_info(data)`][update_info] with a `dict` of the group properties to update.  This
 method returns a new [`Group`][group_class] object with the updates applied, leaving the original object unmodified.
 
+<!-- sample put_groups_id -->
 ```python
 group_update = {'name': 'New Group Name'}
 updated_group = client.group(group_id='11111').update_info(group_update)
@@ -108,6 +112,7 @@ Delete a Group
 To delete a group, call [`group.delete()`][delete].  This method returns `True` to indicate that the deletion was
 successful.
 
+<!-- sample delete_groups_id -->
 ```python
 client.group(group_id='11111').delete()
 print('The group was deleted!')
@@ -123,6 +128,7 @@ To retrieve all collaborations for a group, call
 `BoxObjectCollection` that allows you to iterate over the [`Collaboration`][collaboration_class] objects in the
 collection.
 
+<!-- sample get_groups_id_collaborations -->
 ```python
 collaborations = client.group(group_id='11111').get_collaborations()
 for collaboration in collaborations:
@@ -143,6 +149,7 @@ the user in the group.
 You can optionally specify the user's `role` in the group, and for users with an admin role you can configure which
 permissions they have in the group by passing a `dict` of [group permissions][permissions] to `configurable_permissions`.
 
+<!-- sample post_group_memberships -->
 ```python
 user = client.user('1111')
 membership = client.group(group_id='11111').add_member(user)
@@ -162,6 +169,7 @@ To retrieve information about a group membership, first call
 about the group membership from the API.  This returns a new [`GroupMembership`][membership_class] object with fields
 populated by data from the API, leaving the original object unmodified.
 
+<!-- sample get_group_memberships_id -->
 ```python
 membership_id = '11111'
 membership = client.group_membership(membership_id).get()
@@ -178,6 +186,7 @@ To update a group membership, call [`membership.update_info(data)`][update_info]
 on the membership object.  This method returns a new [`GroupMembership`][membership_class] object with the changes
 applied, leaving the original object unmodified.
 
+<!-- sample put_group_memberships_id -->
 ```python
 membership_id = '1234'
 membership_update = {'role': 'admin'}
@@ -191,6 +200,7 @@ Remove User from Group
 To remove a user from a group, delete their associated group membership by calling [`group_membership.delete()`][delete].
 This method returns `True` to indicate that the deletion was successful.
 
+<!-- sample delete_group_memberships_id -->
 ```python
 membership_id = '1234'
 client.group_membership(membership_id).delete() 
@@ -205,6 +215,7 @@ To retrieve all of the memberships for a given group, call
 `BoxObjectCollection` that allows you to iterate over all of the [`GroupMembership`][membership_class] objects in the
 collection.
 
+<!-- sample get_groups_id_memberships -->
 ```python
 group_memberships = client.group(group_id='11111').get_memberships()
 for membership in group_memberships:
@@ -221,6 +232,7 @@ To retrieve all of the groups a user belongs to, get a list of their associated 
 `BoxObjectCollection` that allows you to iterate over the [`GroupMembership`][membership_class] objects in the
 collection.
 
+<!-- sample get_users_id_memberships -->
 ```python
 user_memberships = client.user(user_id='33333').get_group_memberships()
 for membership in user_memberships:

--- a/docs/usage/legal_hold.md
+++ b/docs/usage/legal_hold.md
@@ -37,6 +37,7 @@ to initialize the [`LegalHoldPolicy`][policy_class] and then call [`legal_hold_p
 retrieve data from the API.  This method returns a new [`LegalHoldPolicy`][policy_class] object with fields populated by
 data form the API, leaving the original object unmodified.
 
+<!-- sample get_legal_hold_policies_id -->
 ```python
 legal_hold_policy = client.legal_hold_policy(policy_id='12345').get()
 print('The "{0}" policy is {1}'.format(legal_hold_policy.policy_name, legal_hold_policy.status))
@@ -55,6 +56,7 @@ You can optionally pass a `policy_name` value to filter the results to include o
 prefix match by name.  This method returns a `BoxObjectCollection` that allows you to iterate over the
 [`LegalHoldPolicy`][policy_class] objects in the collection.
 
+<!-- sample get_legal_hold_policies -->
 ```python
 policies = client.get_legal_hold_policies()
 for policy in policies:
@@ -72,6 +74,7 @@ well as parameters describing which time period the policy applies to.  You must
 and `filter_ending_at` dates, or `is_ongoing=True`.  This method returns a new [`LegalHoldPolicy`][policy_class] object
 representing the created policy.
 
+<!-- sample post_legal_hold_policies -->
 ```python
 new_policy = client.create_legal_hold_policy('New Policy', is_ongoing=True)
 print('Created legal hold policy with ID {0}'.format(new_policy.id))
@@ -86,6 +89,7 @@ To update an existing legal hold policy, call [`legal_hold_policy.update_info(da
 properties to update on the policy.  This method returns a new [`LegalHoldPolicy`][policy_class] object with the updates
 applied, leaving the original object unmodified.
 
+<!-- sample put_legal_hold_policies_id -->
 ```python
 policy_update = {'description': 'New Description', 'release_notes': 'Example Notes'}
 updated_policy = client.legal_hold_policy(policy_id='12345').update_info(policy_update)
@@ -102,6 +106,7 @@ the deletion request was successful.
 > __Note:__ This is an asynchronous process - the policy assignment may not be fully deleted yet when the
 > response comes back.
 
+<!-- sample delete_legal_hold_policies_id -->
 ```python
 client.legal_hold_policy(policy_id='12345').delete()
 print('Legal hold policy was deleted!')
@@ -116,6 +121,7 @@ To assign a legal hold policy, call [`legal_hold_policy.assign(assignee)`][assig
 to a [`Folder`][folder_class], [`File`][file_class], [`FileVersion`][file_version_class], or [`User`][user_class].
 This will cause the associated items to be held and unable to be deleted.
 
+<!-- sample post_legal_hold_policy_assignments -->
 ```python
 folder_to_assign = client.folder(folder_id='22222')
 assignment = client.legal_hold_policy(policy_id'12345').assign(folder_to_assign)
@@ -140,6 +146,7 @@ To get the assignments for a specific legal hold policy, call
 This method returns a `BoxObjectCollection` that allows you to iterate over the
 [`LegalHoldPolicyAssignment`][assignment_class] objects in the collection.
 
+<!-- sample get_legal_hold_policy_assignments -->
 ```python
 assignments = client.legal_hold_policy(policy_id='12345').get_assignments()
 for assignment in assignments:
@@ -168,6 +175,7 @@ retrieve data about the assignment from the API.  This method returns a new
 [`LegalHoldPolicyAssignment`][assignment_class] with fields populated by data from the API, leaving the original object
 unmodified.
 
+<!-- sample get_legal_hold_policy_assignments_id -->
 ```python
 assignment_id = '98765'
 assignment = client.legal_hold_policy_assignment(assignment_id).get()
@@ -189,6 +197,7 @@ returns `True` to indicate that the deletion request was successful.
 > __Note:__ This is an asynchronous process - the policy assignment may not be fully deleted yet when the
 > response comes back.
 
+<!-- sample delete_legal_hold_policy_assignments_id -->
 ```python
 assignment_id = '1111'
 client.legal_hold_policy_assignment(assignment_id).delete()
@@ -202,6 +211,7 @@ To get the actual hold records associated with a policy, call
 `BoxObjectCollection` that allows you to iterate over the [`LegalHold`][hold_class] objects in the
 collection.
 
+<!-- sample get_file_version_legal_holds -->
 ```python
 legal_holds = client.legal_hold_policy(policy_id='12345').get_file_version_legal_holds()
 for legal_hold in legal_holds:
@@ -218,6 +228,7 @@ To retrieve information about a file version legal hold, call [`legal_hold.get(f
 returns a new [`LegalHold`][hold_class] with fields populated by data from the API, leaving the original object
 unmodified.
 
+<!-- sample get_file_version_legal_holds_id -->
 ```python
 file_version_legal_hold_id = '55555'
 legal_hold = client.legal_hold(file_version_legal_hold_id).get()

--- a/docs/usage/metadata.md
+++ b/docs/usage/metadata.md
@@ -45,6 +45,7 @@ You can optionally specify a key for the template, otherwise one will be derived
 time, only `enterprise` scope templates are supported.  This method returns a
 [`MetadataTemplate`][metadata_template_class] object representing the created template.
 
+<!-- sample post_metadata_templates_schema -->
 ```python
 from boxsdk.object.metadata_template import MetadataField, MetadataFieldType
 
@@ -72,6 +73,7 @@ To retrieve a specific template by scope and template key, first use
 the template.  This method returns a new [`MetadataTemplate`][metadata_template_class] object with fields populated by
 data from the API, leaving the original object unmodified.
 
+<!-- sample get_metadata_templates_id_id_schema -->
 ```python
 template = client.metadata_template('enterprise', 'employeeRecord').get()
 print('The {0} template has {1} fields'.format(template.displayName, len(template.fields)))
@@ -86,6 +88,7 @@ To retrieve a template by ID, call [`client.get_metadata_template_by_id(template
 metadata template.  This method returns a [`MetadataTemplate`][metadata_template_class] object with fields populated by
 data from the API.
 
+<!-- sample get_metadata_templates_id -->
 ```python
 template = client.metadata_template_by_id(template_id='abcdef-fba434-ace44').get()
 print('The {0} template has {1} fields'.format(template.displayName, len(template.fields)))
@@ -102,6 +105,7 @@ necessary update operations, and then call [`template.update_info(updates)`][upd
 apply the changes to the metadata template.  This method returns an updated
 [`MetadataTemplate`][metadata_template_class] object with the changes applied, leaving the original object unmodified.
 
+<!-- sample put_metadata_templates_id_id_schema -->
 ```python
 template = client.metadata_template('enterprise', 'employeeRecord')
 updates = template.start_update()
@@ -123,6 +127,7 @@ By default, this retrieves all templates scoped to the current enterprise, but y
 retrieve templates for a different scope.  This method returns a [`BoxObjectCollection`][box_object_collection] that
 allows you to iterate over all the [`MetadataTemplate`][metadata_template_class] objects in the collection.
 
+<!-- sample get_metadata_templates_enterprise -->
 ```python
 templates = client.get_metadata_templates()
 for template in templates:
@@ -138,6 +143,7 @@ Delete Metadata Template
 To delete a metadata template, call [`template.delete()`][delete].  This method returns `True` to indicate the deletion
 was successful.
 
+<!-- sample delete_metadata_templates_id_id -->
 ```python
 client.metadata_template('enterprise', 'employeeRecord').delete()
 ```

--- a/docs/usage/metadata.md
+++ b/docs/usage/metadata.md
@@ -143,7 +143,7 @@ Delete Metadata Template
 To delete a metadata template, call [`template.delete()`][delete].  This method returns `True` to indicate the deletion
 was successful.
 
-<!-- sample delete_metadata_templates_id_id -->
+<!-- sample delete_metadata_templates_id_id_schema -->
 ```python
 client.metadata_template('enterprise', 'employeeRecord').delete()
 ```

--- a/docs/usage/metadata_cascade_policies.md
+++ b/docs/usage/metadata_cascade_policies.md
@@ -28,6 +28,7 @@ To create a metadata cascade policy on a folder, call [`folder.cascade_metadata(
 with the [`MetadataTemplate`][metadata_template_class] whose values should be cascaded within the folder.  This
 method returns a [`MetadataCascadePolicy`][cascade_policy_class] object representing the newly-created policy.
 
+<!-- sample post_metadata_cascade_policies -->
 ```python
 folder = client.folder(folder_id='22222')
 metadata_template = client.metadata_template('enterprise', 'securityClassiciation')
@@ -53,6 +54,7 @@ To retrieve information about a metadata cascade policy, first call
 the policy.  This method returns a new [`MetadataCascadePolicy`][cascade_policy_class] object with fields populated by
 data from the API, leaving the original object unmodified.
 
+<!-- sample get_metadata_cascade_policies_id -->
 ```python
 cascade_policy = client.metadata_cascade_policy('84113349-794d-445c-b93c-d8481b223434').get()
 print('Cascade policy applies to a template owned by enterprise {0}'.format(cascade_policy.owner_enterprise.id))
@@ -71,6 +73,7 @@ cascade policies related to templates for a specific enterprise; if not specifie
 enterprise.  This method returns a [`BoxObjectCollection`][box_object_collection] that allows you to iterate over the
 [`MetadataCascadePolicy`][cascade_policy_class] objects in the collection.
 
+<!-- sample get_metadata_cascade_policies -->
 ```python
 cascade_policies = client.folder(folder_id='22222').get_metadata_cascade_policies()
 for policy in cascade_policies:
@@ -90,6 +93,7 @@ files in the folder already have metadata values that conflict with the ones bei
 can choose to either preserve the existing values or overwrite them with the folder's values.  This method returns
 `True` to indicate that the force application was successful.
 
+<!-- sample post_metadata_cascade_policies_id_apply -->
 ```python
 from boxsdk.object.metadata_cascade_policy import CascadePolicyConflictResolution
 
@@ -106,6 +110,7 @@ Remove Cascade Policy
 A metadata cascade policy can be removed from a folder by calling [`cascade_policy.delete()`][delete].  This method
 returns `True` to indicate that the deletion was successful.
 
+<!-- sample delete_metadata_cascade_policies_id -->
 ```python
 client.metadata_cascade_policy(policy_id='84113349-794d-445c-b93c-d8481b223434').delete()
 print('Cascade policy successfully removed')

--- a/docs/usage/retention_policy.md
+++ b/docs/usage/retention_policy.md
@@ -26,6 +26,7 @@ Create Retention Policy
 To create a retention policy object, call [`client.create_retention_policy(policy_name, disposition_action, retention_length, can_owner_extend_retention=None, are_owners_notified=None, custom_notification_recipients=None)`][create_retention_policy]. This will let you create a new indefinite 
 [`RetentionPolicy`][retention_policy_class] object populated with data from the API.
 
+<!-- sample post_retention_policies -->
 ```python
 policy_name = 'Test Indefinite Policy Name'
 disposition_action = 'remove_retention'
@@ -54,6 +55,7 @@ To get a retention policy object, first call [`client.retention_policy(policy_id
 appropriate [`RetentionPolicy`][retention_policy_class] object, and then calling [`retention_policy.get(fields=None)`][get] 
 will return the [`RetentionPolicy`][retention_policy_class] object populated with data from the API.
 
+<!-- sample get_retention_policies_id -->
 ```python
 retention_policy = client.retention_policy(policy_id='12345').get()
 print('Retention Policy ID is {0} and the name is {1}'.format(retention_policy.id, retention_policy.policy_name))
@@ -69,6 +71,7 @@ To retrieve all retention policies for an enterprise, call [`client.get_retentio
 This method returns a `BoxObjectCollection` that allows you to iterate over the 
 [`Retention Policy`][retention_policy_class] objects in the collection.
 
+<!-- sample get_retention_policies -->
 ```python
 retention_policies = client.get_retention_policies()
 for policy in retention_policies:
@@ -84,6 +87,7 @@ To update a retention policy object, calling [`retention_policy.update_info(data
 properties to update on the retention policy. This method returns a newly updates 
 [`RetentionPolicy`][retention_policy_class] object, leaving the original object unmodified.
 
+<!-- sample put_retention_policies_id -->
 ```python
 policy_update = {'policy_name': 'New Policy Name',}
 updated_retention_policy = client.retention_policy(policy_id='12345').update_info(policy_update)
@@ -98,6 +102,7 @@ Assign Retention Policy
 To assign a retention policy, call [`retention_policy.assign(folder)`][assign] will create a new 
 [`RetentionPolicyAssignment`][retention_policy_assignment_class] object populated with data from the API.
 
+<!-- sample post_retention_policy_assignments -->
 ```python
 folder = client.folder(folder_id='1111')
 assignment = client.retention_policy(policy_id='12345').assign(folder)
@@ -115,6 +120,7 @@ to construct the appropriate [`Retention Policy Assignment`][retention_policy_as
 [`retention_policy_assignment.get(fields=None)`][get] will return the 
 [`Retention Policy Assignment`][retention_policy_assignment_class] object populated with data from the API.
 
+<!-- sample get_retention_policy_assignments_id -->
 ```python
 assignment = client.retention_policy_assignment('12345').get()
 print('Assignment id is {0} and it is assigned by {1}'.format(assignment.id, assignment.assigned_by.name))
@@ -132,6 +138,7 @@ To retrieve all retention policy assignments for an enterprise, call
 will return a `BoxObjectCollection` that allows you to iterate over the 
 [`RetentionPolicyAssignment`][retention_policy_assignment_class] objects in the collection.
 
+<!-- sample get_retention_policy_assignments -->
 ```python
 assignments = client.retention_policy(policy_id='12345').assignments(limit=10)
 for assignment in assignments:
@@ -156,6 +163,7 @@ To retrieve all file version retentions, call [`client.get_file_version_retentio
 `BoxObjectCollection` that allows you to iterate over the [`FileVersionRetention`][file_version_retention_class] 
 objects in the collection.
 
+<!-- sample get_file_version_retentions -->
 ```python
 retentions = client.get_file_version_retentions()
 for retention in retentions:
@@ -174,6 +182,7 @@ to construct the appropriate [`File Version Retention`][file_version_retention_c
 [`file_version_retention.get(fields=None)`][get] will return the [`FileVersionRetention`][file_version_retention] 
 object populated with data from the API.
 
+<!-- sample get_file_version_retentions_id -->
 ```python
 retention_info = client.file_version_retention(retention_id='12345').get()
 print('The file version retention ID is {0} and the data time applied at is {1}'.format(retention.id, retention.applied_at))

--- a/docs/usage/retention_policy.md
+++ b/docs/usage/retention_policy.md
@@ -138,7 +138,7 @@ To retrieve all retention policy assignments for an enterprise, call
 will return a `BoxObjectCollection` that allows you to iterate over the 
 [`RetentionPolicyAssignment`][retention_policy_assignment_class] objects in the collection.
 
-<!-- sample get_retention_policy_assignments -->
+<!-- sample get_retention_policy_id_assignments -->
 ```python
 assignments = client.retention_policy(policy_id='12345').assignments(limit=10)
 for assignment in assignments:

--- a/docs/usage/storage_policy.md
+++ b/docs/usage/storage_policy.md
@@ -25,6 +25,7 @@ To get a storage policy object, first call [`client.storage_policy(policy_id)`][
 appropriate [`Storage Policy`][storage_policy_class] object, and then calling [`storage_policy.get(fields=None)`][get] 
 will return the [`StoragePolicy`][storage_policy_class] object populated with data from the API.
 
+<!-- sample get_storage_policies_id -->
 ```python
 storage_policy = client.storage_policy(policy_id='12345').get()
 print('Storage Policy ID is {0} and name is {1}'.format(storage_policy.id, storage_policy.name))
@@ -41,6 +42,7 @@ To retrieve all storage policies for an enterprise, call [`client.get_storage_po
 This method returns a `BoxObjectCollection` that allows you to iterate over the [`StoragePolicy`][storage_policy_class] 
 objects in the collection.
 
+<!-- sample get_storage_policies -->
 ```python
 storage_policies = client.get_storage_policies(limit=100)
 for storage_policy in storage_policies:
@@ -55,6 +57,7 @@ Assign a Storage Policy to a User
 To assign a storage policy to a user, call [`storage_policy.assign(user)`][assign] will create a 
 [`StoragePolicyAssignment`][storage_policy_assignment_class] object with data populated from the API.
 
+<!-- sample post_storage_policy_assignments -->
 ```python
 user = client.user(user_id='12345')
 assignment = client.storage_policy(policy_id='56781').assign(user)
@@ -95,6 +98,7 @@ to construct the appropriate [`Storage Policy Assignment`][storage_policy_assign
 [`storage_policy_assignment.get(fields=None)`][get] will return the [`StoragePolicyAssignment`][storage_policy_assignment_class] 
 object populated with data from the API.
 
+<!-- sample get_storage_policy_assignments_id -->
 ```python
 assignment = client.storage_policy_assignment(assignment_id='12345').get()
 print('Assignment ID is {0} and the storage policy ID is {1}'.format(assignment.id, assignment.storage_policy.id))
@@ -110,6 +114,7 @@ Get Assignment for User
 To get a storage policy assignment object for a user, calling [`user.get_storage_policy_assignment()`][user_assignment] will 
 return the [`StoragePolicyAssignment`][storage_policy_assignment_class] object populated with data from the API.
 
+<!-- sample get_storage_policy_assignments -->
 ```python
 assignment = client.user(user_id='12345').get_storage_policy_assignment()
 print('Assignment ID is {0} and the storage policy ID is {1}'.format(assignment.id, assignment.storage_policy.id))
@@ -124,6 +129,7 @@ Delete Assignment
 To delete a storage policy assignment, call [`storage_policy_assignment.delete()`][delete]. This method returns `True` 
 to indicate that the deletion was successful.
 
+<!-- sample delete_storage_policy_assignments_id -->
 ```python
 client.storage_policy_assignment(assignment_id='12345').delete()
 print('The storage policy assignment was successfully delete!')

--- a/docs/usage/storage_policy.md
+++ b/docs/usage/storage_policy.md
@@ -79,6 +79,7 @@ If the user already has an assignment, you can call [storage_policy_assignment.u
 [`StoragePolicyAssignment`][storage_policy_assignment] object with data populated from the API, leaving the original 
 object unmodified.
 
+<!-- sample put_storage_policy_assignments_id -->
 ```python
 updated_storage_policy = {'storage_policy': {'type': 'storage_policy', 'id': '12345'}}
 updated_assignment = client.storage_policy_assignment(assignment_id='ZW50ZXJwcmldfgeV82MDMwMDQ=').update_info(updated_storage_policy)

--- a/docs/usage/task.md
+++ b/docs/usage/task.md
@@ -143,7 +143,7 @@ task object. Then call ['task.get_assignments(fields=None)'][get_assignments]. T
 `BoxObjectCollection` that allows you to iterate over the ['TaskAssignment'][assignment_class] objects in the 
 collection.
 
-<!-- sample get_task_assignments -->
+<!-- sample get_task_id_assignments -->
 ```python
 assignments = client.task(task_id='12345').get_assignments()
 for assignment in assignments:

--- a/docs/usage/task.md
+++ b/docs/usage/task.md
@@ -28,6 +28,7 @@ To get a task object, first call [`client.task(task_id)`][task] to construct the
 object, and then calling [`task.get(fields=None)`][get] will return the [`Task`][task_class] object populated with data 
 from the API, leaving the original object unmodified.
 
+<!-- sample get_tasks_id -->
 ```python
 task = client.task(task_id='12345').get()
 print('Task ID is {0} and the type is {1}'.format(task.id, task.type))
@@ -43,6 +44,7 @@ List Tasks on File
 To retrieve all tasks on a file, call [`file.get_tasks(fields=None)`]['get_tasks'] will return a `BoxObjectCollection` 
 that allows you to iterate over the [`Task`][task_class] objects in the collection.
 
+<!-- sample get_files_id_tasks -->
 ```python
 tasks = client.file(file_id='11111').get_tasks()
 for task in tasks:
@@ -58,6 +60,7 @@ Add Task to File
 To create a single task for a single user on a single file, call [`file.create_task(message=None, due_at=None)`][create_task] 
 will return a newly created [`Task`][task_class] object populated with data from the API.
 
+<!-- sample post_tasks -->
 ```python
 message = 'Please review this'
 due_at = "2014-04-03T11:09:43-07:00"
@@ -73,6 +76,7 @@ Update Task Info
 To update a task object, first call [`task.update_info(data)`][update_info] with a `dict` of properties to update on the 
 task. This method returns a newly updated [`Task`][task_class] object, leaving the original object unmodified.
 
+<!-- sample put_tasks_id -->
 ```python
 task_update = {'message': 'New Message', 'due_at': '2014-04-03T11:09:43-10:00',}
 updated_task = client.task(task_id='12345').update_info(task_update)
@@ -88,6 +92,7 @@ Delete a Task
 To delete a task, first call [`client.task(task_id)`][task] to construct the appropriate task object, and then call 
 [`task.delete()`][delete]. This method returns `True` to indicate that the deleteion was successful.
 
+<!-- sample delete_tasks_id -->
 ```python
 client.client.task('12345').delete()
 print('The task was successfully delete!')
@@ -104,6 +109,7 @@ To assign a task object, first call [`client.task(task_id)`][task] to construct 
 [`task.assign(user)`][assign] will return an [`Task Assignment`][assignment_class] object, populated with data 
 from the API.
 
+<!-- sample post_task_assignments -->
 ```python
 user = client.user(user_id='11111')
 assignment = client.task(task_id='12345').assign(user)
@@ -137,6 +143,7 @@ task object. Then call ['task.get_assignments(fields=None)'][get_assignments]. T
 `BoxObjectCollection` that allows you to iterate over the ['TaskAssignment'][assignment_class] objects in the 
 collection.
 
+<!-- sample get_task_assignments -->
 ```python
 assignments = client.task(task_id='12345').get_assignments()
 for assignment in assignments:
@@ -153,6 +160,7 @@ To get a task assignment object, first call [`client.task_assignment(assignment_
 appropriate [`TaskAssignment`][assignment_class] object, and then calling ['task_assignment.get(fields=None)'][get] 
 will return the [`TaskAssignment`][task_assignment] object populated with data from the API.
 
+<!-- sample get_task_assignments_id -->
 ```python
 assignment= client.task_assignment('12345').get()
 print('Assignment ID is {0} and assignment type is {1}'.format(assignment.id, assignment.type))
@@ -169,6 +177,7 @@ To update a task assignment object, call [`assignment.update_info(data)`][update
 with a `dict` of properties to update on a task assignment. This method returns a newly update 
 [`TaskAssignment`][assignment_class] object, leaving the original object unmodified.
 
+<!-- sample put_task_assignments_id -->
 ```python
 from boxsdk.object.task_assignment import ResolutionState
 updated_task = {'resolution_state': ResolutionState.APPROVED}
@@ -185,6 +194,7 @@ Delete Task Assignment
 To delete a task assignment, call [`task_assignment.delete()`][delete]. This method returns `True` to indicate that the 
 deletion was successful.
 
+<!-- sample delete_task_assignments_id -->
 ```python
 client.task_assignment(assignment_id='12345').delete()
 print('The task assignment was successfully delete!')

--- a/docs/usage/terms_of_service.md
+++ b/docs/usage/terms_of_service.md
@@ -100,7 +100,7 @@ object already exists for a user. If the user does not have a [`TermsOfService`]
 assigned then [`terms_of_service.set_user_status(is_accepted, user)`][set_user_status] will create a new 
 [`TermsOfServiceUserStatus`][terms_of_service_user_status_class] object populated with data from the API.
 
-<!-- sample put_terms_of_service_user_statuses_id -->
+<!-- sample post_terms_of_service_user_statuses -->
 ```python
 user = client.user(user_id='22222')
 user_status = client.terms_of_service(tos_id='12345').set_user_status(is_accepted=True, user=user)
@@ -115,6 +115,7 @@ Terms of Service and you wish to change their status, call [`terms_of_service_us
 with a `dict` of properties to update on the terms of service user status. This method returns a newly updated 
 [`TermsOfServiceUserStatus`][terms_of_service_user_status_class] object, leaving the original object unmodified.
 
+<!-- sample put_terms_of_service_user_statuses_id -->
 ```python
 user_status = client.terms_of_service_user_status(tos_user_status_id='12345').update_info({'is_accepted': True})
 print('Terms of Service User Status ID is {0} and the accepted status is {1}'.format(user_status.id, user_status.is_accepted))

--- a/docs/usage/terms_of_service.md
+++ b/docs/usage/terms_of_service.md
@@ -28,6 +28,7 @@ To create a Terms of Service object, calling [`client.create_terms_of_service(st
 you create a new [`TermsOfService`][terms_of_service_class] object with the specified status, type, and text. This 
 method will return a newly created [`TermsOfService`][terms_of_service_class] object populated with data from the API.
 
+<!-- sample post_terms_of_services -->
 ```python
 from boxsdk.object.terms_of_service import TermsOfServiceType, TermsOfServiceStatus
 terms_of_service = client.create_terms_of_service(TermsOfServiceStatus.ENABLED,TermsOfServiceType.MANAGED, 'Example Text')
@@ -44,6 +45,7 @@ To update a terms of service object, first call [`terms_of_service.update_info(d
 properties to update on the terms of service. This method returns a newly updated [`TermsOfService`][terms_of_service] 
 object, leaving the original object unmodified.
 
+<!-- sample put_terms_of_services_id -->
 ```python
 update_object = {'text': 'New Text'}
 updated_tos = client.terms_of_service(tos_id='12345').update_info(update_object)
@@ -61,6 +63,7 @@ To get a terms of service object, call [`client.terms_of_service(service_id)`][t
 appropriate [`TermsOfService`][terms_of_service_class], and then calling [`terms_of_service.get(fields=None)`][get] 
 will return the [`TermsOfService`][terms_of_service_class] object populated with data from the API.
 
+<!-- sample get_terms_of_services_id -->
 ```python
 terms_of_service = client.terms_of_service(tos_id='12345').get()
 print('Terms of Service ID is {0} and the message is {1}'.format(terms_of_service.id, terms_of_service.text))
@@ -78,6 +81,7 @@ To retrieve all terms of service for an enterprise, call
 `BoxObjectCollection` that allows you to iterate over the [`TermOfService`][terms_of_service_class] objects in the 
 collection.
 
+<!-- sample get_terms_of_services -->
 ```python
 terms_of_services = client.get_terms_of_services()
 for terms_of_service in terms_of_services:
@@ -96,6 +100,7 @@ object already exists for a user. If the user does not have a [`TermsOfService`]
 assigned then [`terms_of_service.set_user_status(is_accepted, user)`][set_user_status] will create a new 
 [`TermsOfServiceUserStatus`][terms_of_service_user_status_class] object populated with data from the API.
 
+<!-- sample put_terms_of_service_user_statuses_id -->
 ```python
 user = client.user(user_id='22222')
 user_status = client.terms_of_service(tos_id='12345').set_user_status(is_accepted=True, user=user)
@@ -136,6 +141,7 @@ to construct the appropriate [`TermsOfServiceUserStatus`][terms_of_service_user_
 [`terms_of_service_user_status.get(fields=None)`][get] will return the 
 [`TermsOfServiceUserStatus`][terms_of_service_user_status_class] object populated with data from the API.
 
+<!-- sample get_terms_of_service_user_statuses_id -->
 ```python
 user = client.user(user_id='11111')
 user_status = client.terms_of_service(tos_id='12345').get_user_status(user)

--- a/docs/usage/trash.md
+++ b/docs/usage/trash.md
@@ -23,6 +23,7 @@ To retrieve all trashed items for an enterprise, call [`client.trash().get_items
 This method returns a `BoxObjectCollection` that allows you to iterate over the [`Trash`][trash] objects in the 
 collection.
 
+<!-- sample get_folders_trash_items -->
 ```python
 trashed_items = client.trash().get_items()
 for trashed_item in trashed_items:
@@ -38,18 +39,21 @@ Get Trashed Items
 To get a trashed item, call [`client.trash().get_item(item, fields)`][get_item] with the item you wish to retrieve passed in. 
 This method will return the ['Item'][item] object populated with data from the API.
 
+<!-- sample get_files_id_trash -->
 ```python
 file_to_retrieve = client.file(file_id='11111')
 file_from_trash = client.trash().get_item(file_to_retrieve)
 print('File ID is {0} and name is {1}'.format(file_from_trash.id, file_from_trash.name))
 ```
 
+<!-- sample get_folders_id_trash -->
 ```python
 folder = client.folder(folder_id='22222')
 folder_from_trash = client.trash().get_item(folder)
 print('Folder ID is {0} and name is {1}'.format(folder_from_trash.id, folder_from_trash.name))
 ```
 
+<!-- sample get_web_links_id_trash -->
 ```python
 web_link = client.web_link(web_link_i='33333')
 web_link_from_trash = client.trash().get_item(web_link)
@@ -66,18 +70,20 @@ To retore a trashed item, effectively undeleting it, call [`client.trash().resto
 with the constructed [`Item`][item_class] object will let you restore the specific object from your trash. This method 
 will return a [`Item`][item_class] object populated with data from the API, leaving the original object unmodified.
 
+<!-- sample post_files_id -->
 ```python
 file_to_restore = client.file(file_id='11111')
 restored_file = client.trash().restore_item(file_to_restore)
 print('File ID is {0} and name is {1}'.format(restored_file.id, restored_file.name))
 ```
-
+<!-- sample post_folders_id -->
 ```python
 folder_to_restore = client.folder(folder_id='22222')
 restored_folder = client.trash().restore_item(folder_to_restore)
 print('Folder ID is {0} and name is {1}'.format(restored_folder.id, restored_folder.name))
 ```
 
+<!-- sample post_web_links_id -->
 ```python
 web_link_to_restore = client.web_link(web_link_id='33333')
 restored_web_link = client.trash().restore_item(web_link_to_restore)
@@ -103,18 +109,21 @@ Permanently Delete Item
 To delete an [`Item`][item_class] object from trash, call [`client.trash().permanently_delete_item(item)`][delete]. 
 This method returns `True` to indicate that the deletion was successful.
 
+<!-- sample delete_files_id_trash -->
 ```python
 file_to_delete = client.file(file_id='11111')
 client.trash().permanently_delete_item(file_to_delete)
 print('The file was deleted from trash!')
 ```
 
+<!-- sample delete_folders_id_trash -->
 ```python
 folder = client.folder(folder_id='22222')
 client.trash().permanently_delete_item(folder)
 print('The folder was deleted from trash!')
 ```
 
+<!-- sample delete_web_links_id_trash -->
 ```python
 web_link = client.web_link(web_link_id='33333')
 client.trash().permanently_delete_item(web_link)

--- a/docs/usage/user.md
+++ b/docs/usage/user.md
@@ -29,6 +29,7 @@ Get User Information
 To get information about a user, call the [`user.get(fields=None)`][object_get] method.  This method returns a new
 [`User`][user_class] object with fields populated by data from the API.
 
+<!-- sample get_users_id -->
 ```python
 user_id = '33333'
 user = client.user(user_id).get()
@@ -53,6 +54,7 @@ Get the Current User's Information
 To get the current user, call [`client.user(user_id='me')`][user_init] to create the [`User`][user_class] object and
 then call [`user.get(fields=None)`][object_get] to retrieve the user information from the API.
 
+<!-- sample get_users_me -->
 ```python
 current_user = client.user().get()
 ```
@@ -65,6 +67,7 @@ Create An Enterprise User
 To create an enterprise user, call the [`client.create_user(name, login, **user_attributes)`][create_user] method.
 This method returns a new [`User`][user_class] object.
 
+<!-- sample post_users -->
 ```python
 new_user = client.create_user('Dummy User', 'user@example.com')
 ```
@@ -77,6 +80,7 @@ Get the Avatar for a User
 To get the avatar for a user call the [`user.get_avatar()`][get_avatar] method with the [`User`][user_class] 
 object for the user you wish to retrieve an avatar for. This will return the user avatar to you in bytes.
 
+<!-- sample get_users_id_avatar -->
 ```python
 avatar = client.user('33333').get_avatar()
 ```
@@ -102,6 +106,7 @@ Update User
 To update a user object, call the [`user.update_info(data)`][update_info] method with a `dict` of fields to update
 on the user.
 
+<!-- sample put_users_id -->
 ```python
 user_id = '33333'
 user = client.user(user_id)
@@ -120,6 +125,7 @@ The `notify` parameter determines whether the user should receive an email about
 and the `force` parameter will cause the user to be deleted even if they still have files in their account.  If `force`
 is set to `False` and the user still has files in their account, the deletion will fail.
 
+<!-- sample delete_users_id -->
 ```python
 user_id = '33333'
 client.user(user_id).delete(force=True)
@@ -133,6 +139,7 @@ Invite User to Enterprise
 To invite an existing user to join an Enterprise call the [`enterprise.invite_user(user_email)`][invite_user] method.  This
 method returns an [`Invite`][invite_class] object representing the status of the invitation.
 
+<!-- sample post_invites -->
 ```python
 enterprise = client.get_current_enterprise()
 invitation = enterprise.invite_user('user@example.com')
@@ -148,6 +155,7 @@ To get a user's email aliases call the [`user.get_email_aliases(limit=None, fiel
 This method returns a [`BoxObjectCollection`][box_object_collection] used to iterate over the collection of
 [`EmailAlias`][email_alias_class] objects.
 
+<!-- sample get_users_id_email_aliases -->
 ```python
 user_id = '33333'
 user = client.user(user_id)
@@ -167,6 +175,7 @@ To add an email alias for a user, call the [`user.add_email_alias(email)`][add_e
 address to add as an email alias for the user.  This will allow the user to log in and be collaborated by this email
 in addition to their login email address.  The method returns an [`EmailAlias`][email_alias_class] object.
 
+<!-- sample post_users_id_email_aliases -->
 ```python
 user_id = '33333'
 user = client.user(user_id)
@@ -181,6 +190,7 @@ Remove Email Alias
 To remove an email alias from a user, call the [`user.remove_email_alias(email_alias)`][remove_email_alias] method with
 the [`EmailAlias`][email_alias_class] object to remove.  The method returns `True` to signify that the removal succeeded.
 
+<!-- sample delete_users_id_email_aliases_id -->
 ```python
 user_id = '33333'
 email_alias_id = '12345'
@@ -202,6 +212,7 @@ a `filter_term` to filter on the user's `name` and `login` fields, or select a `
 managed or external users.  This method returns a [`BoxObjectCollection`][box_object_collection] used to iterate over
 the collection of [`User`][user_class] objects.
 
+<!-- sample get_users -->
 ```python
 users = client.users(user_type='all')
 for user in users:
@@ -219,6 +230,7 @@ To move all of a user's content to a different user, call the
 account, containing all files and folders from the original user's account; the method returns a
 [`Folder`][folder_class] object representing this new folder in the destination user's account.
 
+<!-- sample put_users_id_folders_id -->
 ```python
 source_user_id = '33333'
 destination_user_id = '44444'

--- a/docs/usage/watermarking.md
+++ b/docs/usage/watermarking.md
@@ -48,13 +48,13 @@ To assign a watermark on a file or folder, call [file.apply_watermark()][apply-f
 [folder.apply_watermark()][apply-folder-watermark] will return the [`Watermark`][watermark_class] object populated with 
 data from the API.
 
-<!-- sample post_files_id_watermark -->
+<!-- sample put_files_id_watermark -->
 ```python
 watermark = client.file(file_id='12345').apply_watermark()
 print('Watermark created at {0} and modified at {1}'.format(watermark.created_at, watermark.modified_at))
 ```
 
-<!-- sample post_folders_id_watermark -->
+<!-- sample put_folders_id_watermark -->
 ```python
 watermark = client.folder(folder_id='11111').apply_watermark()
 print('Watermark created at {0} and modified at {1}'.format(watermark.created_at, watermark.modified_at))

--- a/docs/usage/watermarking.md
+++ b/docs/usage/watermarking.md
@@ -25,11 +25,13 @@ To get a watermark object, call  [`file.get_watermark()`][get_file_watermark] or
 [`folder.get_watermark()`][get_folder_watermark] will return the [`Watermark`][watermark_class] object populated with 
 data from the API.
 
+<!-- sample get_files_id_watermark -->
 ```python
 watermark = client.file(file_id='12345').get_watermark()
 print('Watermark created at {0} and modified at {1}'.format(watermark.created_at, watermark.modified_at))
 ```
 
+<!-- sample get_folders_id_watermark -->
 ```python
 watermark = client.folder(folder_id='11111').get_watermark()
 print('Watermark created at {0} and modified at {1}'.format(watermark.created_at, watermark.modified_at))
@@ -46,11 +48,13 @@ To assign a watermark on a file or folder, call [file.apply_watermark()][apply-f
 [folder.apply_watermark()][apply-folder-watermark] will return the [`Watermark`][watermark_class] object populated with 
 data from the API.
 
+<!-- sample post_files_id_watermark -->
 ```python
 watermark = client.file(file_id='12345').apply_watermark()
 print('Watermark created at {0} and modified at {1}'.format(watermark.created_at, watermark.modified_at))
 ```
 
+<!-- sample post_folders_id_watermark -->
 ```python
 watermark = client.folder(folder_id='11111').apply_watermark()
 print('Watermark created at {0} and modified at {1}'.format(watermark.created_at, watermark.modified_at))
@@ -66,11 +70,13 @@ Remove Watermark on File or Folder
 To remove a watermark from a file or folder, call [file.delete_watermark()][delete-file-watermark] or 
 [folder.delete_watermark()][delete-folder-watermark] will return `True` to indicate that the deletion was successful.
 
+<!-- sample delete_files_id_watermark -->
 ```python
 client.file(file_id='12345').delete_watermark()
 print('The file watermark was deleted!')
 ```
 
+<!-- sample delete_folders_id_watermark -->
 ```python
 client.folder(folder_id='11111').delete_watermark()
 print('The folder watermark was deleted!')

--- a/docs/usage/web_link.md
+++ b/docs/usage/web_link.md
@@ -23,6 +23,7 @@ To create a web link object, calling [`folder.create_web_link(target_url, name=N
 will let you create a new web link with a specified name and description. This method return an newly created [`WebLink`][web_link_class] 
 object populated with data from the API, leaving the original object unmodified.
 
+<!-- sample post_web_links -->
 ```python
 web_link = client.folder(folder_id='12345').create_web_link('https://example.com', 'Example Link', 'This is the description')
 print('Web Link url is {0} and its description is {1}'.format(web_link.url, web_link.description))
@@ -38,6 +39,7 @@ To get a web link object, first call [`client.web_link(web_link_id)`][web_link] 
 [`WebLink`][web_link_class] object, and then calling [`web_link.get(fields=None)`][get] will return the 
 [`WebLink`][web_link_class] object populated with data from the API, leaving the original object unmodified.
 
+<!-- sample get_web_links_id -->
 ```python
 web_link = client.web_link(web_link_id='12345').get()
 print('Web Link ID is {0} and its type is {1}'.format(web_link.id, web_link.type))
@@ -54,6 +56,7 @@ To update a web link object, call [`web_link.update_info(data)`][update_info] wi
 properties to update on the web link. This method returns a newly updated ['WebLink'][web_link_class] object, leaving 
 the original object unmodified.
 
+<!-- sample put_web_links_id -->
 ```python
 updated_web_link = client.web_link(web_link_id='12345').update_info({'url': 'https://newurl.com'})
 ```
@@ -67,6 +70,7 @@ Delete Web Link
 To delete a web link, call [`web_link.delete()`][delete]. This method returns `True` to indicate that the deletion was 
 successful.
 
+<!-- sample delete_web_links_id -->
 ```python
 client.web_link('12345').delete()
 print('The web link was deleted!')

--- a/docs/usage/webhook.md
+++ b/docs/usage/webhook.md
@@ -25,6 +25,7 @@ To get a webhook object, first call [`client.webhook(webhook_id)`][webhook] to c
 [`Webhook`][webhook_class] object, and then calling [`webhook.get(fields=None)`][get] will return the 
 [`Webhook`][webhook_class] object populated with data from the API.
 
+<!-- sample get_webhooks_id -->
 ```python
 webhook = client.webhook(webhook_id='12345').get()
 print('Webhooks ID is {0} and the address is {1}'.format(webhook.id, webhook.address))
@@ -41,6 +42,7 @@ To retrieve all webhooks for an enterprise, call [`client.get_webhooks(limit=Non
 This method returns a `BoxObjectCollection` that allows you to iterate over the [`Webhook`][webhook_class] objects in 
 the collection.
 
+<!-- sample get_webhooks -->
 ```python
 webhooks = client.get_webhooks()
 for webhook in webhooks:
@@ -57,6 +59,7 @@ To create a webhook object, call [`client.create_webhook(target_url, name=None, 
 you create a new webhook object with the specified target url, name, and description. This method will return an updated 
 [`Webhook`][webhook_class] object populated with data from the API, leaving the original object unmodified.
 
+<!-- sample post_webhooks -->
 ```python
 folder = client.folder(folder_id='12345')
 webhook = client.create_webhook(folder, ['FILE.UPLOADED', 'FILE.PREVIEWED'], 'https://example.com')
@@ -72,6 +75,7 @@ Delete Webhook
 To delete a webhook, call [`webhook.delete()`][delete]. This method returns `True` to indicate that the deletion was 
 successful.
 
+<!-- sample delete_webhooks_id -->
 ```python
 client.webhook(webhook_id='12345').delete()
 print('The webhook was successfully deleted!')
@@ -87,6 +91,7 @@ To update a webhook object, first call [`client.webhook(webhook_id)`][webhook] t
 object, and then calling [`webhook.update_info(data)`][update_info] with a `dict` of properties to update on the 
 webhook. This method returns a new updated [`Webhook`][webhook_class] object, leaving the original object unmodified.
 
+<!-- sample put_webhooks_id -->
 ```python
 update_object = {
     'triggers': ['FILE.COPIED'],


### PR DESCRIPTION
I've tagged the majority of code samples to an endpoint for usage in the new developer documentation.