### PR TITLE
Limit line length for get_folders_id

### DIFF
--- a/docs/usage/folders.md
+++ b/docs/usage/folders.md
@@ -43,7 +43,8 @@ ones not returned by default.
 <!-- sample get_folders_id -->
 ```python
 folder = client.folder(folder_id='22222').get()
-print('Folder "{0}" has {1} items in it'.format(folder.name, folder.item_collection.total_count))
+print('Folder "{0}" has {1} items in it'
+      .format(folder.name, folder.item_collection.total_count))
 ```
 
 [folder]: https://box-python-sdk.readthedocs.io/en/latest/boxsdk.client.html#boxsdk.client.client.Client.folder


### PR DESCRIPTION
Reduced the line length for the `get_folders_id` sample in order to make it render nicely on box.dev