### PR TITLE
Add get event by details

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -9,3 +9,4 @@ used to interact with the Box API. This is a list of contributors.
 - `@nsundareswaran <https://github.com/nsundareswaran>`_
 - `@kelseymorris95 <https://github.com/kelseymorris95>`_
 - `@sp4x <https://github.com/sp4x>`_
+- `@capk1rk <https://github.com/capk1rk>`_

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,8 +3,12 @@
 Release History
 ---------------
 
+Upcoming
+++++++++++++++++++
+- Added a new get events function with created_before, created_after, and event_type parameters
+
 2.5.0 (2019-06-20)
-+++++++++++++++++
+++++++++++++++++++
 - Allowed passing `None` to clear configurable_permission field in the add_member() method.
 
 2.4.1 (2019-05-16)

--- a/boxsdk/object/events.py
+++ b/boxsdk/object/events.py
@@ -96,6 +96,52 @@ class Events(BaseEndpoint):
         return self.translator.translate(self._session, response_object=response)
 
     @api_call
+    def get_events_by_details(self, limit=100, created_after=None, created_before=None, event_type=None, stream_type=UserEventsStreamType.ALL):
+        """
+        Get Box events from a datetime, to a datetime, or between datetimes with a given event type for a given
+        stream type. Works for Enterprise and User stream types
+
+        :param limit:
+            Maximum number of events to return.
+        :type limit:
+            `int`
+        :param created_after:
+            (optional) Start date in ISO format to pull events from
+            Defaults to `None`
+        :type created_after:
+            `string`
+        :param created_before:
+            (optional) End date in ISO format to pull events to
+            Defaults to `None`
+        :type created_before:
+            `string`
+        :param event_type:
+            (optional) Which events to return (ie. LOGIN)
+        :type event_type:
+            `string`
+        :param stream_type:
+            (optional) Which type of events to return.
+            Defaults to `UserEventsStreamType.ALL`.
+        :type stream_type:
+            :enum:`EventsStreamType`
+        :returns:
+            Dictionary containing the next stream position along with a list of some number of events.
+        :rtype:
+            `dict`
+        """
+        url = self.get_url()
+        params = {
+            'limit': limit,
+            'created_after': created_after,
+            'created_before': created_before,
+            'event_type': event_type,
+            'stream_type': stream_type,
+        }
+        box_response = self._session.get(url, params=params)
+        response = box_response.json().copy()
+        return self.translator.translate(self._session, response_object=response)
+
+    @api_call
     def get_latest_stream_position(self, stream_type=UserEventsStreamType.ALL):
         """
         Get the latest stream position. The return value can be used with :meth:`get_events` or


### PR DESCRIPTION
Added a function with the ability to pull events with additional parameters. Almost identical to the original get_events() function. 
- `created_after` Only return events that happen after this date
- `created_before` Only return events that happen before this date
- `event_type` Type of events to limit response too

All of the parameters are optional. All of these parameters are incompatible with stream positions. Max limit of 500. The Box API documentation says that `created_after` and `created_before` parameters only work with admin logs. From my testing, it works with all stream types. 