### PR TITLE
Support for adding enterprise events with date filter.

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -9,3 +9,4 @@ used to interact with the Box API. This is a list of contributors.
 - `@nsundareswaran <https://github.com/nsundareswaran>`_
 - `@kelseymorris95 <https://github.com/kelseymorris95>`_
 - `@sp4x <https://github.com/sp4x>`_
+- `@capk1rk <https://github.com/capk1rk>`_

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,8 +3,12 @@
 Release History
 ---------------
 
+Upcoming
+++++++++++++++++++
+- Added a new get events function with created_before, created_after, and event_type parameters
+
 2.5.0 (2019-06-20)
-+++++++++++++++++
+++++++++++++++++++
 - Allowed passing `None` to clear configurable_permission field in the add_member() method.
 
 2.4.1 (2019-05-16)

--- a/boxsdk/object/events.py
+++ b/boxsdk/object/events.py
@@ -96,6 +96,52 @@ class Events(BaseEndpoint):
         return self.translator.translate(self._session, response_object=response)
 
     @api_call
+    def get_events_by_details(self, limit=100, created_after=None, created_before=None, event_type=None, stream_type=UserEventsStreamType.ALL):
+        """
+        Get Box events from a datetime, to a datetime, or between datetimes with a given event type for a given
+        stream type. Works for Enterprise and User stream types
+
+        :param limit:
+            Maximum number of events to return.
+        :type limit:
+            `int`
+        :param created_after:
+            (optional) Start date in ISO format to pull events from
+            Defaults to `None`
+        :type created_after:
+            `string`
+        :param created_before:
+            (optional) End date in ISO format to pull events to
+            Defaults to `None`
+        :type created_before:
+            `string`
+        :param event_type:
+            (optional) Which events to return (ie. LOGIN)
+        :type event_type:
+            `string`
+        :param stream_type:
+            (optional) Which type of events to return.
+            Defaults to `UserEventsStreamType.ALL`.
+        :type stream_type:
+            :enum:`EventsStreamType`
+        :returns:
+            Dictionary containing the next stream position along with a list of some number of events.
+        :rtype:
+            `dict`
+        """
+        url = self.get_url()
+        params = {
+            'limit': limit,
+            'created_after': created_after,
+            'created_before': created_before,
+            'event_type': event_type,
+            'stream_type': stream_type,
+        }
+        box_response = self._session.get(url, params=params)
+        response = box_response.json().copy()
+        return self.translator.translate(self._session, response_object=response)
+
+    @api_call
     def get_latest_stream_position(self, stream_type=UserEventsStreamType.ALL):
         """
         Get the latest stream position. The return value can be used with :meth:`get_events` or

--- a/boxsdk/object/events.py
+++ b/boxsdk/object/events.py
@@ -117,6 +117,7 @@ class Events(BaseEndpoint):
             `unicode`
         :param event_type:
             (optional) Which events to return (ie. LOGIN)
+            Defaults to `None`
         :type event_type:
             `unicode`
         :returns:

--- a/boxsdk/object/events.py
+++ b/boxsdk/object/events.py
@@ -96,15 +96,15 @@ class Events(BaseEndpoint):
         return self.translator.translate(self._session, response_object=response)
 
     @api_call
-    def get_admin_events_by_details(self, limit=100, created_after=None, created_before=None, event_type=None):
+    def get_admin_events(self, limit=None, created_after=None, created_before=None, event_types=None):
         """
         Get Box Admin events from a datetime, to a datetime, or between datetimes with a given event type for a enterprise
         stream type. Works for Enterprise admin_logs type.
 
         :param limit:
-            Maximum number of events to return.
+            (optional) Maximum number of events to return.
         :type limit:
-            `int`
+            `int` or None
         :param created_after:
             (optional) Start date in datetime format to pull events from
             Defaults to `None`
@@ -115,11 +115,11 @@ class Events(BaseEndpoint):
             Defaults to `None`
         :type created_before:
             `unicode`
-        :param event_type:
+        :param event_types:
             (optional) Which events to return (ie. LOGIN)
             Defaults to `None`
-        :type event_type:
-            `unicode`
+        :type event_types:
+            Array of `unicode`
         :returns:
             Dictionary containing the next stream position along with a list of some number of events.
         :rtype:
@@ -127,14 +127,15 @@ class Events(BaseEndpoint):
         """
         url = self.get_url()
         params = {
-            'limit': limit,
             'created_after': created_after,
             'created_before': created_before,
-            'event_type': event_type,
+            'event_type': ','.join(event_types),
             'stream_type': 'admin_logs',
         }
+        if limit is not None:
+            params['limit'] = limit
         box_response = self._session.get(url, params=params)
-        response = box_response.json().copy()
+        response = box_response.json()
         return self.translator.translate(self._session, response_object=response)
 
     @api_call

--- a/boxsdk/object/events.py
+++ b/boxsdk/object/events.py
@@ -96,34 +96,29 @@ class Events(BaseEndpoint):
         return self.translator.translate(self._session, response_object=response)
 
     @api_call
-    def get_events_by_details(self, limit=100, created_after=None, created_before=None, event_type=None, stream_type=UserEventsStreamType.ALL):
+    def get_admin_events_by_details(self, limit=100, created_after=None, created_before=None, event_type=None):
         """
-        Get Box events from a datetime, to a datetime, or between datetimes with a given event type for a given
-        stream type. Works for Enterprise and User stream types
+        Get Box Admin events from a datetime, to a datetime, or between datetimes with a given event type for a enterprise
+        stream type. Works for Enterprise admin_logs type.
 
         :param limit:
             Maximum number of events to return.
         :type limit:
             `int`
         :param created_after:
-            (optional) Start date in ISO format to pull events from
+            (optional) Start date in datetime format to pull events from
             Defaults to `None`
         :type created_after:
-            `string`
+            `unicode`
         :param created_before:
-            (optional) End date in ISO format to pull events to
+            (optional) End date in datetime format to pull events to
             Defaults to `None`
         :type created_before:
-            `string`
+            `unicode`
         :param event_type:
             (optional) Which events to return (ie. LOGIN)
         :type event_type:
-            `string`
-        :param stream_type:
-            (optional) Which type of events to return.
-            Defaults to `UserEventsStreamType.ALL`.
-        :type stream_type:
-            :enum:`EventsStreamType`
+            `unicode`
         :returns:
             Dictionary containing the next stream position along with a list of some number of events.
         :rtype:
@@ -135,7 +130,7 @@ class Events(BaseEndpoint):
             'created_after': created_after,
             'created_before': created_before,
             'event_type': event_type,
-            'stream_type': stream_type,
+            'stream_type': 'admin_logs',
         }
         box_response = self._session.get(url, params=params)
         response = box_response.json().copy()

--- a/docs/usage/events.md
+++ b/docs/usage/events.md
@@ -98,17 +98,18 @@ for event in events['entries']:
     print('Got {0} event that occurred at {1}'.format(event.event_type, event.created_at))
 ```
 
-### Get Events Between Two Dates
+### Get Admin Events
 
-The SDK also allows you to retrieve enterprise events before and after a certain date with the specified `event_type` by calling
-[`events.get_admin_events_by_details(self, limit=100, created_after=None, created_before=None, event_type=None)`][admin_events_details].
+The SDK also allows you to retrieve enterprise events, you can specify before and after a certain datetime and the types of events to retrieve with the `event_type` by calling
+[`events.get_admin_events(self, limit=None, created_after=None, created_before=None, event_types=None)`][admin_events_details].
 The format for the `created_after` and `created_before` fields are supported by [RFC 3339](https://www.ietf.org/rfc/rfc3339.txt) and look
-something like this: 2019-08-12T09:12:36-00:00. For more information on the date format that Box accepts please see [here](https://developer.box.com/reference#section-date-format).
+something like this: 2019-08-12T09:12:36-00:00. For more information on the date format please see [here](https://developer.box.com/reference#section-date-format).
 
 ```python
- events = client.events().get_admin_events_by_details(created_after='2019-07-01T22:02:24-07:00', created_before='2019-08-07T22:02:24-07:00', event_type='ITEM_CREATE')
+ events = client.events()
+    .get_admin_events(created_after='2019-07-01T22:02:24-07:00', event_types=['ITEM_CREATE'])
  for event in events['entries']:
     print('Got {0} event that occurred at {1}'.format(event.event_type, event.created_at)) 
 ```
 
-[admin_events_details]: https://box-python-sdk.readthedocs.io/en/latest/boxsdk.object.html#boxsdk.object.events.Events.get_admin_events_by_details
+[admin_events_details]: https://box-python-sdk.readthedocs.io/en/latest/boxsdk.object.html#boxsdk.object.events.Events.get_admin_events

--- a/docs/usage/events.md
+++ b/docs/usage/events.md
@@ -97,3 +97,18 @@ stream_position = events['next_stream_position']
 for event in events['entries']:
     print('Got {0} event that occurred at {1}'.format(event.event_type, event.created_at))
 ```
+
+### Get Events Between Two Dates
+
+The SDK also allows you to retrieve enterprise events before and after a certain date with the specified `event_type` by calling
+[`events.get_admin_events_by_details(self, limit=100, created_after=None, created_before=None, event_type=None)`][admin_events_details].
+The format for the `created_after` and `created_before` fields are supported by [RFC 3339](https://www.ietf.org/rfc/rfc3339.txt) and look
+something like this: 2019-08-12T09:12:36-00:00. For more information on the date format that Box accepts please see [here](https://developer.box.com/reference#section-date-format).
+
+```python
+ events = client.events().get_admin_events_by_details(created_after='2019-07-01T22:02:24-07:00', created_before='2019-08-07T22:02:24-07:00', event_type='ITEM_CREATE')
+ for event in events['entries']:
+    print('Got {0} event that occurred at {1}'.format(event.event_type, event.created_at)) 
+```
+
+[admin_events_details]: https://box-python-sdk.readthedocs.io/en/latest/boxsdk.object.html#boxsdk.object.events.Events.get_admin_events_by_details

--- a/test/unit/object/test_events.py
+++ b/test/unit/object/test_events.py
@@ -214,6 +214,34 @@ def test_get_events(
         assert event.event_id == json['event_id']
 
 
+def test_get_events_by_details(
+        test_events,
+        mock_box_session,
+        events_response,
+):
+    # pylint:disable=redefined-outer-name
+    expected_url = test_events.get_url()
+    mock_box_session.get.return_value = events_response
+    events = test_events.get_events_by_details(
+        created_after='2019-07-01T22:02:24-07:00',
+        created_before='2019-08-07T22:02:24-07:00',
+        event_type='ITEM_CREATE'
+        )
+    mock_box_session.get.assert_called_with(
+        expected_url,
+        params=dict(
+            created_after='2019-07-01T22:02:24-07:00',
+            created_before='2019-08-07T22:02:24-07:00',
+            event_type='ITEM_CREATE',
+            limit=100,
+            stream_type='admin_logs'
+        )
+    )
+    for event, json in zip(events['entries'], events_response.json.return_value['entries']):
+        assert isinstance(event, Event)
+        assert event.event_id == json['event_id']
+
+
 def test_get_long_poll_options(
         mock_box_session,
         test_events,

--- a/test/unit/object/test_events.py
+++ b/test/unit/object/test_events.py
@@ -214,7 +214,7 @@ def test_get_events(
         assert event.event_id == json['event_id']
 
 
-def test_get_events_by_details(
+def test_get_admin_events(
         test_events,
         mock_box_session,
         events_response,
@@ -222,18 +222,17 @@ def test_get_events_by_details(
     # pylint:disable=redefined-outer-name
     expected_url = test_events.get_url()
     mock_box_session.get.return_value = events_response
-    events = test_events.get_admin_events_by_details(
+    events = test_events.get_admin_events(
         created_after='2019-07-01T22:02:24-07:00',
         created_before='2019-08-07T22:02:24-07:00',
-        event_type='ITEM_CREATE'
+        event_types=['ITEM_CREATE', "LOGIN"]
     )
     mock_box_session.get.assert_called_with(
         expected_url,
         params=dict(
             created_after='2019-07-01T22:02:24-07:00',
             created_before='2019-08-07T22:02:24-07:00',
-            event_type='ITEM_CREATE',
-            limit=100,
+            event_type='ITEM_CREATE,LOGIN',
             stream_type='admin_logs'
         )
     )

--- a/test/unit/object/test_events.py
+++ b/test/unit/object/test_events.py
@@ -214,7 +214,6 @@ def test_get_events(
         assert event.event_id == json['event_id']
 
 
-
 @pytest.mark.parametrize("limit", [100, None])
 def test_get_admin_events(
         test_events,

--- a/test/unit/object/test_events.py
+++ b/test/unit/object/test_events.py
@@ -222,7 +222,7 @@ def test_get_events_by_details(
     # pylint:disable=redefined-outer-name
     expected_url = test_events.get_url()
     mock_box_session.get.return_value = events_response
-    events = test_events.get_events_by_details(
+    events = test_events.get_admin_events_by_details(
         created_after='2019-07-01T22:02:24-07:00',
         created_before='2019-08-07T22:02:24-07:00',
         event_type='ITEM_CREATE'

--- a/test/unit/object/test_events.py
+++ b/test/unit/object/test_events.py
@@ -226,7 +226,7 @@ def test_get_events_by_details(
         created_after='2019-07-01T22:02:24-07:00',
         created_before='2019-08-07T22:02:24-07:00',
         event_type='ITEM_CREATE'
-        )
+    )
     mock_box_session.get.assert_called_with(
         expected_url,
         params=dict(

--- a/test/unit/object/test_events.py
+++ b/test/unit/object/test_events.py
@@ -214,27 +214,40 @@ def test_get_events(
         assert event.event_id == json['event_id']
 
 
+
+@pytest.mark.parametrize("limit", [100, None])
 def test_get_admin_events(
         test_events,
         mock_box_session,
         events_response,
+        limit,
 ):
     # pylint:disable=redefined-outer-name
     expected_url = test_events.get_url()
     mock_box_session.get.return_value = events_response
     events = test_events.get_admin_events(
+        limit=limit,
         created_after='2019-07-01T22:02:24-07:00',
         created_before='2019-08-07T22:02:24-07:00',
-        event_types=['ITEM_CREATE', "LOGIN"]
+        event_types=['ITEM_CREATE', "LOGIN"],
     )
-    mock_box_session.get.assert_called_with(
-        expected_url,
-        params=dict(
+    expected_params = dict(
+        created_after='2019-07-01T22:02:24-07:00',
+        created_before='2019-08-07T22:02:24-07:00',
+        event_type='ITEM_CREATE,LOGIN',
+        stream_type='admin_logs',
+    )
+    if limit:
+        expected_params = dict(
             created_after='2019-07-01T22:02:24-07:00',
             created_before='2019-08-07T22:02:24-07:00',
             event_type='ITEM_CREATE,LOGIN',
-            stream_type='admin_logs'
+            stream_type='admin_logs',
+            limit=limit,
         )
+    mock_box_session.get.assert_called_with(
+        expected_url,
+        params=expected_params
     )
     for event, json in zip(events['entries'], events_response.json.return_value['entries']):
         assert isinstance(event, Event)


### PR DESCRIPTION
Minor changes to the pr originally submitted by @capk1rk. The fields `created_after` and `created_before` only work with enterprise events. Although if you include these fields with the stream_type set to `ALL` the events that is returned is not indicative of the range set.

We altered the original function to only allow enterprise events by setting the `admin_logs` manually for `stream_type`.

A test was added as well that asserts more importantly(than the response) that the request sent over has the correct query parameters. Readme was also updated for events.