### PR TITLE
Fix on pydoc of get_items of folder.py

### DIFF
--- a/boxsdk/object/folder.py
+++ b/boxsdk/object/folder.py
@@ -179,7 +179,7 @@ class Folder(Item):
         Get the items in a folder.
 
         :param limit:
-            The maximum number of items to return.
+            The maximum number of items to return per page. If not specified, then will use the server-side default.
         :type limit:
             `int` or None
         :param offset:


### PR DESCRIPTION
I'd like to have this document fixed: https://box-python-sdk.readthedocs.io/en/latest/boxsdk.object.html#boxsdk.object.folder.Folder.get_items

Per https://github.com/box/box-python-sdk/issues/366,
> the "limit" actually refers to the limit on items you get back from the API per page. 

This limitation should be reflected to the above doc.

I see that the description of `limit` parameter of other class [Collection](https://box-python-sdk.readthedocs.io/en/latest/boxsdk.object.html#boxsdk.object.collection.Collection.get_items) and [Trash](https://box-python-sdk.readthedocs.io/en/latest/boxsdk.object.html#boxsdk.object.trash.Trash.get_items) have already reflected this point. I hope this will be corrected for "Folder".