### PR TITLE
Fixed `get_admin_events` Optional `event_types` Parameter

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -10,3 +10,4 @@ used to interact with the Box API. This is a list of contributors.
 - `@kelseymorris95 <https://github.com/kelseymorris95>`_
 - `@sp4x <https://github.com/sp4x>`_
 - `@capk1rk <https://github.com/capk1rk>`_
+- `@aculler <https://github.com/aculler>`_

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,10 @@
 Release History
 ---------------
 
+Upcoming
+++++++++
+- Fixed bug in get_admin_events function which caused errors when the optional event_types parameter was omitted.
+
 2.6.1 (2019-10-24)
 ++++++++++++++++++
 - Added api_ call decorator for copy method.

--- a/boxsdk/object/events.py
+++ b/boxsdk/object/events.py
@@ -129,11 +129,12 @@ class Events(BaseEndpoint):
         params = {
             'created_after': created_after,
             'created_before': created_before,
-            'event_type': ','.join(event_types),
             'stream_type': 'admin_logs',
         }
         if limit is not None:
             params['limit'] = limit
+        if event_types is not None:
+            params['event_type'] = ','.join(event_types)
         box_response = self._session.get(url, params=params)
         response = box_response.json()
         return self.translator.translate(self._session, response_object=response)


### PR DESCRIPTION
Per #463, I updated the `get_admin_events` function to properly handle the case where the `event_types` optional parameter is omitted.

Fixes #463.