### PR TITLE
Support additional file attributes on upload (#472)

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -11,3 +11,4 @@ used to interact with the Box API. This is a list of contributors.
 - `@sp4x <https://github.com/sp4x>`_
 - `@capk1rk <https://github.com/capk1rk>`_
 - `@aculler <https://github.com/aculler>`_
+- `@ben-reilly <https://github.com/ben-reilly>`_

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,6 +6,7 @@ Release History
 Upcoming
 ++++++++
 - Fixed bug in get_admin_events function which caused errors when the optional event_types parameter was omitted.
+- Added support for more attribute parameters when uploading new files and new versions of existing files.
 
 2.6.1 (2019-10-24)
 ++++++++++++++++++

--- a/boxsdk/object/file.py
+++ b/boxsdk/object/file.py
@@ -190,13 +190,13 @@ class File(Item):
     def update_contents_with_stream(
             self,
             file_stream,
-            file_name=None,
-            file_modified_at=None,
-            additional_attributes=None,
             etag=None,
             preflight_check=False,
             preflight_expected_size=0,
             upload_using_accelerator=False,
+            file_name=None,
+            file_modified_at=None,
+            additional_attributes=None,
     ):
         """
         Upload a new version of a file, taking the contents from the given file stream.
@@ -205,18 +205,6 @@ class File(Item):
             The file-like object containing the bytes
         :type file_stream:
             `file`
-        :param file_name:
-            The new name to give the file on Box.
-        :type file_name:
-            `unicode` or None
-        :param file_modified_at:
-            The RFC-3339 datetime when the file was last modified.
-        :type file_modified_at:
-            `unicode` or None
-        :param additional_attributes:
-            A dictionary containing attributes to add to the file that are not covered by other parameters.
-        :type additional_attributes:
-            `dict` or None
         :param etag:
             If specified, instruct the Box API to update the item only if the current version's etag matches.
         :type etag:
@@ -239,6 +227,18 @@ class File(Item):
             Please notice that this is a premium feature, which might not be available to your app.
         :type upload_using_accelerator:
             `bool`
+        :param file_name:
+            The new name to give the file on Box.
+        :type file_name:
+            `unicode` or None
+        :param file_modified_at:
+            The RFC-3339 datetime when the file was last modified.
+        :type file_modified_at:
+            `unicode` or None
+        :param additional_attributes:
+            A dictionary containing attributes to add to the file that are not covered by other parameters.
+        :type additional_attributes:
+            `dict` or None
         :returns:
             A new file object
         :rtype:
@@ -287,13 +287,13 @@ class File(Item):
     def update_contents(
             self,
             file_path,
-            file_name=None,
-            file_modified_at=None,
-            additional_attributes=None,
             etag=None,
             preflight_check=False,
             preflight_expected_size=0,
             upload_using_accelerator=False,
+            file_name=None,
+            file_modified_at=None,
+            additional_attributes=None,
     ):
         """Upload a new version of a file. The contents are taken from the given file path.
 
@@ -301,18 +301,6 @@ class File(Item):
             The path of the file that should be uploaded.
         :type file_path:
             `unicode`
-        :param file_name:
-            The new name to give the file on Box.
-        :type file_name:
-            `unicode` or None
-        :param file_modified_at:
-            The RFC-3339 datetime when the file was last modified.
-        :type file_modified_at:
-            `unicode` or None
-        :param additional_attributes:
-            A dictionary containing attributes to add to the file that are not covered by other parameters.
-        :type additional_attributes:
-            `dict` or None
         :param etag:
             If specified, instruct the Box API to update the item only if the current version's etag matches.
         :type etag:
@@ -335,6 +323,18 @@ class File(Item):
             Please notice that this is a premium feature, which might not be available to your app.
         :type upload_using_accelerator:
             `bool`
+        :param file_name:
+            The new name to give the file on Box.
+        :type file_name:
+            `unicode` or None
+        :param file_modified_at:
+            The RFC-3339 datetime when the file was last modified.
+        :type file_modified_at:
+            `unicode` or None
+        :param additional_attributes:
+            A dictionary containing attributes to add to the file that are not covered by other parameters.
+        :type additional_attributes:
+            `dict` or None
         :returns:
             A new file object
         :rtype:
@@ -346,13 +346,13 @@ class File(Item):
         with open(file_path, 'rb') as file_stream:
             return self.update_contents_with_stream(
                 file_stream,
-                file_name,
-                file_modified_at,
-                additional_attributes,
                 etag,
                 preflight_check,
                 preflight_expected_size=preflight_expected_size,
                 upload_using_accelerator=upload_using_accelerator,
+                file_name=file_name,
+                file_modified_at=file_modified_at,
+                additional_attributes=additional_attributes,
             )
 
     @api_call

--- a/boxsdk/object/file.py
+++ b/boxsdk/object/file.py
@@ -190,6 +190,9 @@ class File(Item):
     def update_contents_with_stream(
             self,
             file_stream,
+            file_name=None,
+            file_modified_at=None,
+            additional_attributes=None,
             etag=None,
             preflight_check=False,
             preflight_expected_size=0,
@@ -244,9 +247,23 @@ class File(Item):
             if accelerator_upload_url:
                 url = accelerator_upload_url
 
+        attributes = {
+            'name': file_name,
+            'content_modified_at': file_modified_at,
+        }
+        if additional_attributes:
+            attributes.update(additional_attributes)
+
+        data = {'attributes': json.dumps(attributes)}
         files = {'file': ('unused', file_stream)}
         headers = {'If-Match': etag} if etag is not None else None
-        file_response = self._session.post(url, expect_json_response=False, files=files, headers=headers).json()
+        file_response = self._session.post(
+            url,
+            expect_json_response=False,
+            data=data,
+            files=files,
+            headers=headers,
+        ).json()
         if 'entries' in file_response:
             file_response = file_response['entries'][0]
         return self.translator.translate(

--- a/boxsdk/object/file.py
+++ b/boxsdk/object/file.py
@@ -205,6 +205,18 @@ class File(Item):
             The file-like object containing the bytes
         :type file_stream:
             `file`
+        :param file_name:
+            The new name to give the file on Box.
+        :type file_name:
+            `unicode` or None
+        :param file_modified_at:
+            The RFC-3339 datetime when the file was last modified.
+        :type file_modified_at:
+            `unicode` or None
+        :param additional_attributes:
+            A dictionary containing attributes to add to the file that are not covered by other parameters.
+        :type additional_attributes:
+            `dict` or None
         :param etag:
             If specified, instruct the Box API to update the item only if the current version's etag matches.
         :type etag:
@@ -275,6 +287,9 @@ class File(Item):
     def update_contents(
             self,
             file_path,
+            file_name=None,
+            file_modified_at=None,
+            additional_attributes=None,
             etag=None,
             preflight_check=False,
             preflight_expected_size=0,
@@ -286,6 +301,18 @@ class File(Item):
             The path of the file that should be uploaded.
         :type file_path:
             `unicode`
+        :param file_name:
+            The new name to give the file on Box.
+        :type file_name:
+            `unicode` or None
+        :param file_modified_at:
+            The RFC-3339 datetime when the file was last modified.
+        :type file_modified_at:
+            `unicode` or None
+        :param additional_attributes:
+            A dictionary containing attributes to add to the file that are not covered by other parameters.
+        :type additional_attributes:
+            `dict` or None
         :param etag:
             If specified, instruct the Box API to update the item only if the current version's etag matches.
         :type etag:
@@ -319,6 +346,9 @@ class File(Item):
         with open(file_path, 'rb') as file_stream:
             return self.update_contents_with_stream(
                 file_stream,
+                file_name,
+                file_modified_at,
+                additional_attributes,
                 etag,
                 preflight_check,
                 preflight_expected_size=preflight_expected_size,

--- a/boxsdk/object/folder.py
+++ b/boxsdk/object/folder.py
@@ -271,6 +271,18 @@ class Folder(Item):
             The description to give the file on Box.
         :type file_description:
             `unicode` or None
+        :param file_created_at:
+            The RFC-3339 datetime when the file was created.
+        :type file_created_at:
+            `unicode` or None
+        :param file_modified_at:
+            The RFC-3339 datetime when the file was last modified.
+        :type file_modified_at:
+            `unicode` or None
+        :param additional_attributes:
+            A dictionary containing attributes to add to the file that are not covered by other parameters.
+        :type additional_attributes:
+            `dict` or None
         :param preflight_check:
             If specified, preflight check will be performed before actually uploading the file.
         :type preflight_check:
@@ -331,6 +343,9 @@ class Folder(Item):
             file_path=None,
             file_name=None,
             file_description=None,
+            file_created_at=None,
+            file_modified_at=None,
+            additional_attributes=None,
             preflight_check=False,
             preflight_expected_size=0,
             upload_using_accelerator=False,
@@ -352,6 +367,18 @@ class Folder(Item):
             The description to give the file on Box. If None, then no description will be set.
         :type file_description:
             `unicode` or None
+        :param file_created_at:
+            The RFC-3339 datetime when the file was created.
+        :type file_created_at:
+            `unicode` or None
+        :param file_modified_at:
+            The RFC-3339 datetime when the file was last modified.
+        :type file_modified_at:
+            `unicode` or None
+        :param additional_attributes:
+            A dictionary containing attributes to add to the file that are not covered by other parameters.
+        :type additional_attributes:
+            `dict` or None
         :param preflight_check:
             If specified, preflight check will be performed before actually uploading the file.
         :type preflight_check:
@@ -382,6 +409,9 @@ class Folder(Item):
                 file_stream,
                 file_name,
                 file_description,
+                file_created_at,
+                file_modified_at,
+                additional_attributes,
                 preflight_check,
                 preflight_expected_size=preflight_expected_size,
                 upload_using_accelerator=upload_using_accelerator,

--- a/boxsdk/object/folder.py
+++ b/boxsdk/object/folder.py
@@ -248,12 +248,12 @@ class Folder(Item):
             file_stream,
             file_name,
             file_description=None,
-            file_created_at=None,
-            file_modified_at=None,
-            additional_attributes=None,
             preflight_check=False,
             preflight_expected_size=0,
             upload_using_accelerator=False,
+            file_created_at=None,
+            file_modified_at=None,
+            additional_attributes=None,
     ):
         """
         Upload a file to the folder.
@@ -271,18 +271,6 @@ class Folder(Item):
             The description to give the file on Box.
         :type file_description:
             `unicode` or None
-        :param file_created_at:
-            The RFC-3339 datetime when the file was created.
-        :type file_created_at:
-            `unicode` or None
-        :param file_modified_at:
-            The RFC-3339 datetime when the file was last modified.
-        :type file_modified_at:
-            `unicode` or None
-        :param additional_attributes:
-            A dictionary containing attributes to add to the file that are not covered by other parameters.
-        :type additional_attributes:
-            `dict` or None
         :param preflight_check:
             If specified, preflight check will be performed before actually uploading the file.
         :type preflight_check:
@@ -301,6 +289,18 @@ class Folder(Item):
             Please notice that this is a premium feature, which might not be available to your app.
         :type upload_using_accelerator:
             `bool`
+        :param file_created_at:
+            The RFC-3339 datetime when the file was created.
+        :type file_created_at:
+            `unicode` or None
+        :param file_modified_at:
+            The RFC-3339 datetime when the file was last modified.
+        :type file_modified_at:
+            `unicode` or None
+        :param additional_attributes:
+            A dictionary containing attributes to add to the file that are not covered by other parameters.
+        :type additional_attributes:
+            `dict` or None
         :returns:
             The newly uploaded file.
         :rtype:
@@ -343,12 +343,12 @@ class Folder(Item):
             file_path=None,
             file_name=None,
             file_description=None,
-            file_created_at=None,
-            file_modified_at=None,
-            additional_attributes=None,
             preflight_check=False,
             preflight_expected_size=0,
             upload_using_accelerator=False,
+            file_created_at=None,
+            file_modified_at=None,
+            additional_attributes=None,
     ):
         """
         Upload a file to the folder.
@@ -367,18 +367,6 @@ class Folder(Item):
             The description to give the file on Box. If None, then no description will be set.
         :type file_description:
             `unicode` or None
-        :param file_created_at:
-            The RFC-3339 datetime when the file was created.
-        :type file_created_at:
-            `unicode` or None
-        :param file_modified_at:
-            The RFC-3339 datetime when the file was last modified.
-        :type file_modified_at:
-            `unicode` or None
-        :param additional_attributes:
-            A dictionary containing attributes to add to the file that are not covered by other parameters.
-        :type additional_attributes:
-            `dict` or None
         :param preflight_check:
             If specified, preflight check will be performed before actually uploading the file.
         :type preflight_check:
@@ -397,6 +385,18 @@ class Folder(Item):
             Please notice that this is a premium feature, which might not be available to your app.
         :type upload_using_accelerator:
             `bool`
+        :param file_created_at:
+            The RFC-3339 datetime when the file was created.
+        :type file_created_at:
+            `unicode` or None
+        :param file_modified_at:
+            The RFC-3339 datetime when the file was last modified.
+        :type file_modified_at:
+            `unicode` or None
+        :param additional_attributes:
+            A dictionary containing attributes to add to the file that are not covered by other parameters.
+        :type additional_attributes:
+            `dict` or None
         :returns:
             The newly uploaded file.
         :rtype:
@@ -409,12 +409,12 @@ class Folder(Item):
                 file_stream,
                 file_name,
                 file_description,
-                file_created_at,
-                file_modified_at,
-                additional_attributes,
                 preflight_check,
                 preflight_expected_size=preflight_expected_size,
                 upload_using_accelerator=upload_using_accelerator,
+                file_created_at=file_created_at,
+                file_modified_at=file_modified_at,
+                additional_attributes=additional_attributes,
             )
 
     @api_call

--- a/boxsdk/object/folder.py
+++ b/boxsdk/object/folder.py
@@ -248,6 +248,9 @@ class Folder(Item):
             file_stream,
             file_name,
             file_description=None,
+            file_created_at=None,
+            file_modified_at=None,
+            additional_attributes=None,
             preflight_check=False,
             preflight_expected_size=0,
             upload_using_accelerator=False,
@@ -300,11 +303,17 @@ class Folder(Item):
             if accelerator_upload_url:
                 url = accelerator_upload_url
 
-        data = {'attributes': json.dumps({
+        attributes = {
             'name': file_name,
             'parent': {'id': self._object_id},
             'description': file_description,
-        })}
+            'content_created_at': file_created_at,
+            'content_modified_at': file_modified_at,
+        }
+        if additional_attributes:
+            attributes.update(additional_attributes)
+
+        data = {'attributes': json.dumps(attributes)}
         files = {
             'file': ('unused', file_stream),
         }

--- a/test/unit/object/test_file.py
+++ b/test/unit/object/test_file.py
@@ -328,8 +328,10 @@ def test_update_contents(
     attributes = {
         'name': file_new_name,
         'content_modified_at': file_modified_at,
-        'attr': 123,
     }
+    # Using `update` to mirror the actual impl, since the attributes could otherwise come through in a different order
+    # in Python 2 tests
+    attributes.update(additional_attributes)
     data = {'attributes': json.dumps(attributes)}
     mock_box_session.post.assert_called_once_with(
         expected_url,

--- a/test/unit/object/test_file.py
+++ b/test/unit/object/test_file.py
@@ -305,11 +305,11 @@ def test_update_contents(
         mock_file_stream = BytesIO(mock_content_response.content)
         new_file = test_file.update_contents_with_stream(
             mock_file_stream,
+            etag=etag,
+            upload_using_accelerator=upload_using_accelerator,
             file_name=file_new_name,
             file_modified_at=file_modified_at,
             additional_attributes=additional_attributes,
-            etag=etag,
-            upload_using_accelerator=upload_using_accelerator,
         )
     else:
         mock_file = mock_open(read_data=mock_content_response.content)
@@ -317,11 +317,11 @@ def test_update_contents(
         with patch('boxsdk.object.file.open', mock_file, create=True):
             new_file = test_file.update_contents(
                 mock_file_path,
+                etag=etag,
+                upload_using_accelerator=upload_using_accelerator,
                 file_name=file_new_name,
                 file_modified_at=file_modified_at,
                 additional_attributes=additional_attributes,
-                etag=etag,
-                upload_using_accelerator=upload_using_accelerator,
             )
 
     mock_files = {'file': ('unused', mock_file_stream)}

--- a/test/unit/object/test_file.py
+++ b/test/unit/object/test_file.py
@@ -3,7 +3,6 @@
 from __future__ import unicode_literals
 import json
 from mock import mock_open, patch
-from os.path import basename
 import pytest
 from six import BytesIO
 from boxsdk.config import API
@@ -288,6 +287,7 @@ def test_update_contents(
         if_match_header,
         is_stream,
 ):
+    # pylint:disable=too-many-locals
     file_new_name = 'new_file_name'
     file_modified_at = '1970-01-01T11:11:11+11:11'
     additional_attributes = {'attr': 123}

--- a/test/unit/object/test_folder.py
+++ b/test/unit/object/test_folder.py
@@ -268,8 +268,10 @@ def test_upload(
         'description': file_description,
         'content_created_at': file_created_at,
         'content_modified_at': file_modified_at,
-        'attr': 123,
     }
+    # Using `update` to mirror the actual impl, since the attributes could otherwise come through in a different order
+    # in Python 2 tests
+    attributes.update(additional_attributes)
     data = {'attributes': json.dumps(attributes)}
     mock_box_session.post.assert_called_once_with(expected_url, expect_json_response=False, files=mock_files, data=data)
     assert isinstance(new_file, File)

--- a/test/unit/object/test_folder.py
+++ b/test/unit/object/test_folder.py
@@ -244,10 +244,10 @@ def test_upload(
             mock_file_stream,
             basename(mock_file_path),
             file_description,
+            upload_using_accelerator=upload_using_accelerator,
             file_created_at=file_created_at,
             file_modified_at=file_modified_at,
             additional_attributes=additional_attributes,
-            upload_using_accelerator=upload_using_accelerator,
         )
     else:
         mock_file = mock_open(read_data=mock_content_response.content)
@@ -256,10 +256,10 @@ def test_upload(
             new_file = test_folder.upload(
                 mock_file_path,
                 file_description=file_description,
+                upload_using_accelerator=upload_using_accelerator,
                 file_created_at=file_created_at,
                 file_modified_at=file_modified_at,
                 additional_attributes=additional_attributes,
-                upload_using_accelerator=upload_using_accelerator,
             )
 
     mock_files = {'file': ('unused', mock_file_stream)}

--- a/test/unit/object/test_folder.py
+++ b/test/unit/object/test_folder.py
@@ -224,6 +224,9 @@ def test_upload(
         is_stream,
 ):
     file_description = 'Test File Description'
+    file_created_at = '1970-01-01T00:00:00+00:00'
+    file_modified_at = '1970-01-01T11:11:11+11:11'
+    additional_attributes = {'attr': 123}
     expected_url = '{0}/files/content'.format(API.UPLOAD_URL)
     if upload_using_accelerator:
         if upload_using_accelerator_fails:
@@ -240,6 +243,9 @@ def test_upload(
             mock_file_stream,
             basename(mock_file_path),
             file_description,
+            file_created_at=file_created_at,
+            file_modified_at=file_modified_at,
+            additional_attributes=additional_attributes,
             upload_using_accelerator=upload_using_accelerator,
         )
     else:
@@ -249,11 +255,22 @@ def test_upload(
             new_file = test_folder.upload(
                 mock_file_path,
                 file_description=file_description,
+                file_created_at=file_created_at,
+                file_modified_at=file_modified_at,
+                additional_attributes=additional_attributes,
                 upload_using_accelerator=upload_using_accelerator,
             )
 
     mock_files = {'file': ('unused', mock_file_stream)}
-    data = {'attributes': json.dumps({'name': basename(mock_file_path), 'parent': {'id': mock_object_id}, 'description': file_description})}
+    attributes = {
+        'name': basename(mock_file_path),
+        'parent': {'id': mock_object_id},
+        'description': file_description,
+        'content_created_at': file_created_at,
+        'content_modified_at': file_modified_at,
+        'attr': 123,
+    }
+    data = {'attributes': json.dumps(attributes)}
     mock_box_session.post.assert_called_once_with(expected_url, expect_json_response=False, files=mock_files, data=data)
     assert isinstance(new_file, File)
     assert new_file.object_id == mock_object_id

--- a/test/unit/object/test_folder.py
+++ b/test/unit/object/test_folder.py
@@ -223,6 +223,7 @@ def test_upload(
         upload_using_accelerator_fails,
         is_stream,
 ):
+    # pylint:disable=too-many-locals
     file_description = 'Test File Description'
     file_created_at = '1970-01-01T00:00:00+00:00'
     file_modified_at = '1970-01-01T11:11:11+11:11'


### PR DESCRIPTION
Added parameters for all attributes explicitly mentioned in the API reference for uploads*, plus added an `additional_attributes` dict that can be optionally filled with key-value pairs with any other attributes the user wants to modify.

This fixes #472.

*See [here for uploading new files](https://developer.box.com/en/reference/post-files-content/) and [here for uploading new file versions](https://developer.box.com/en/reference/post-files-id-content/).