### PR TITLE
Combine preflight and accelerator calls for uploads (#475)

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,6 +6,7 @@ Release History
 Upcoming
 ++++++++
 - Fixed bug in get_admin_events function which caused errors when the optional event_types parameter was omitted.
+- Combine preflight check and lookup of accelerator URL into a single request for uploads.
 
 2.6.1 (2019-10-24)
 ++++++++++++++++++

--- a/boxsdk/object/folder.py
+++ b/boxsdk/object/folder.py
@@ -95,6 +95,7 @@ class Folder(Item):
     def preflight_check(self, size, name):
         """
         Make an API call to check if a new file with given name and size can be uploaded to this folder.
+        Returns an accelerator URL if one is available.
 
         :param size:
             The size of the file in bytes. Specify 0 for unknown file-sizes.
@@ -104,10 +105,14 @@ class Folder(Item):
             The name of the file to be uploaded.
         :type name:
             `unicode`
+        :return:
+            The Accelerator upload url or None if cannot get the Accelerator upload url.
+        :rtype:
+            `unicode` or None
         :raises:
             :class:`BoxAPIException` when preflight check fails.
         """
-        self._preflight_check(
+        return self._preflight_check(
             size=size,
             name=name,
             parent_id=self._object_id,
@@ -291,14 +296,16 @@ class Folder(Item):
         :rtype:
             :class:`File`
         """
+        accelerator_upload_url = None
         if preflight_check:
-            self.preflight_check(size=preflight_expected_size, name=file_name)
+            # Preflight check does double duty, returning the accelerator URL if one is available in the response.
+            accelerator_upload_url = self.preflight_check(size=preflight_expected_size, name=file_name)
+        elif upload_using_accelerator:
+            accelerator_upload_url = self._get_accelerator_upload_url_fow_new_uploads()
 
         url = '{0}/files/content'.format(self._session.api_config.UPLOAD_URL)
-        if upload_using_accelerator:
-            accelerator_upload_url = self._get_accelerator_upload_url_fow_new_uploads()
-            if accelerator_upload_url:
-                url = accelerator_upload_url
+        if upload_using_accelerator and accelerator_upload_url:
+            url = accelerator_upload_url
 
         data = {'attributes': json.dumps({
             'name': file_name,

--- a/boxsdk/object/item.py
+++ b/boxsdk/object/item.py
@@ -55,6 +55,8 @@ class Item(BaseObject):
         Make an API call to check if certain file can be uploaded to Box or not.
         (https://box-content.readme.io/reference#preflight-check)
 
+        Returns an accelerator URL if available, which comes for free in the response.
+
         :param size:
             The size of the file to be uploaded in bytes. Specify 0 for unknown file sizes.
         :type size:
@@ -72,6 +74,10 @@ class Item(BaseObject):
             The ID of the parent folder. Required only for new file uploads.
         :type parent_id:
             `unicode`
+        :return:
+            The Accelerator upload url or None if cannot get the Accelerator upload url.
+        :rtype:
+            `unicode` or None
         :raises:
             :class:`BoxAPIException` when preflight check fails.
         """
@@ -83,11 +89,12 @@ class Item(BaseObject):
         if parent_id:
             data['parent'] = {'id': parent_id}
 
-        self._session.options(
+        response_json = self._session.options(
             url=url,
-            expect_json_response=False,
+            expect_json_response=True,
             data=json.dumps(data),
-        )
+        ).json()
+        return response_json.get('upload_url', None)
 
     @api_call
     def update_info(self, data, etag=None):

--- a/test/unit/object/test_folder.py
+++ b/test/unit/object/test_folder.py
@@ -264,6 +264,37 @@ def test_upload(
     assert 'entries' not in new_file
 
 
+@pytest.mark.parametrize('is_stream', (True, False))
+def test_upload_combines_preflight_and_accelerator_calls_if_both_are_requested(
+        test_folder,
+        mock_box_session,
+        mock_file_path,
+        mock_content_response,
+        mock_accelerator_response_for_new_uploads,
+        is_stream
+):
+    mock_box_session.options.return_value = mock_accelerator_response_for_new_uploads
+
+    if is_stream:
+        mock_file_stream = BytesIO(mock_content_response.content)
+        test_folder.upload_stream(
+            mock_file_stream,
+            basename(mock_file_path),
+            preflight_check=True,
+            upload_using_accelerator=True,
+        )
+    else:
+        mock_file = mock_open(read_data=mock_content_response.content)
+        with patch('boxsdk.object.folder.open', mock_file, create=True):
+            test_folder.upload(
+                mock_file_path,
+                preflight_check=True,
+                upload_using_accelerator=True,
+            )
+
+    mock_box_session.options.assert_called_once()
+
+
 def test_create_upload_session(test_folder, mock_box_session):
     expected_url = '{0}/files/upload_sessions'.format(API.UPLOAD_URL)
     file_size = 197520
@@ -379,12 +410,21 @@ def test_update_sync_state(test_folder, mock_folder_response, mock_box_session, 
     assert update_response.object_id == test_folder.object_id
 
 
-def test_preflight(test_folder, mock_object_id, mock_box_session):
+def test_preflight(
+        test_folder,
+        mock_object_id,
+        mock_box_session,
+        mock_accelerator_response_for_new_uploads,
+        mock_new_upload_accelerator_url,
+):
     new_file_size, new_file_name = 100, 'foo.txt'
-    test_folder.preflight_check(size=new_file_size, name=new_file_name)
+    mock_box_session.options.return_value = mock_accelerator_response_for_new_uploads
+
+    accelerator_url = test_folder.preflight_check(size=new_file_size, name=new_file_name)
+
     mock_box_session.options.assert_called_once_with(
         url='{0}/files/content'.format(API.BASE_API_URL),
-        expect_json_response=False,
+        expect_json_response=True,
         data=json.dumps(
             {
                 'size': new_file_size,
@@ -393,6 +433,7 @@ def test_preflight(test_folder, mock_object_id, mock_box_session):
             }
         ),
     )
+    assert accelerator_url == mock_new_upload_accelerator_url
 
 
 def test_create_web_link_returns_the_correct_web_link_object(test_folder, mock_box_session):


### PR DESCRIPTION
When uploading a file, we can combine the preflight check and the request for an accelerator URL into a single OPTIONS request, since both actions target the same endpoint.