### PR TITLE
Rename upload method parameters to align with API

### DIFF
--- a/boxsdk/object/file.py
+++ b/boxsdk/object/file.py
@@ -200,7 +200,7 @@ class File(Item):
             preflight_expected_size=0,
             upload_using_accelerator=False,
             file_name=None,
-            file_modified_at=None,
+            content_modified_at=None,
             additional_attributes=None,
     ):
         """
@@ -236,9 +236,9 @@ class File(Item):
             The new name to give the file on Box.
         :type file_name:
             `unicode` or None
-        :param file_modified_at:
-            The RFC-3339 datetime when the file was last modified.
-        :type file_modified_at:
+        :param content_modified_at:
+            The RFC-3339 datetime when the file content was last modified.
+        :type content_modified_at:
             `unicode` or None
         :param additional_attributes:
             A dictionary containing attributes to add to the file that are not covered by other parameters.
@@ -268,7 +268,7 @@ class File(Item):
 
         attributes = {
             'name': file_name,
-            'content_modified_at': file_modified_at,
+            'content_modified_at': content_modified_at,
         }
         if additional_attributes:
             attributes.update(additional_attributes)
@@ -299,7 +299,7 @@ class File(Item):
             preflight_expected_size=0,
             upload_using_accelerator=False,
             file_name=None,
-            file_modified_at=None,
+            content_modified_at=None,
             additional_attributes=None,
     ):
         """Upload a new version of a file. The contents are taken from the given file path.
@@ -334,9 +334,9 @@ class File(Item):
             The new name to give the file on Box.
         :type file_name:
             `unicode` or None
-        :param file_modified_at:
-            The RFC-3339 datetime when the file was last modified.
-        :type file_modified_at:
+        :param content_modified_at:
+            The RFC-3339 datetime when the file content was last modified.
+        :type content_modified_at:
             `unicode` or None
         :param additional_attributes:
             A dictionary containing attributes to add to the file that are not covered by other parameters.
@@ -358,7 +358,7 @@ class File(Item):
                 preflight_expected_size=preflight_expected_size,
                 upload_using_accelerator=upload_using_accelerator,
                 file_name=file_name,
-                file_modified_at=file_modified_at,
+                content_modified_at=content_modified_at,
                 additional_attributes=additional_attributes,
             )
 

--- a/boxsdk/object/folder.py
+++ b/boxsdk/object/folder.py
@@ -256,8 +256,8 @@ class Folder(Item):
             preflight_check=False,
             preflight_expected_size=0,
             upload_using_accelerator=False,
-            file_created_at=None,
-            file_modified_at=None,
+            content_created_at=None,
+            content_modified_at=None,
             additional_attributes=None,
     ):
         """
@@ -294,13 +294,13 @@ class Folder(Item):
             Please notice that this is a premium feature, which might not be available to your app.
         :type upload_using_accelerator:
             `bool`
-        :param file_created_at:
+        :param content_created_at:
             The RFC-3339 datetime when the file was created.
-        :type file_created_at:
+        :type content_created_at:
             `unicode` or None
-        :param file_modified_at:
-            The RFC-3339 datetime when the file was last modified.
-        :type file_modified_at:
+        :param content_modified_at:
+            The RFC-3339 datetime when the file content was last modified.
+        :type content_modified_at:
             `unicode` or None
         :param additional_attributes:
             A dictionary containing attributes to add to the file that are not covered by other parameters.
@@ -326,8 +326,8 @@ class Folder(Item):
             'name': file_name,
             'parent': {'id': self._object_id},
             'description': file_description,
-            'content_created_at': file_created_at,
-            'content_modified_at': file_modified_at,
+            'content_created_at': content_created_at,
+            'content_modified_at': content_modified_at,
         }
         if additional_attributes:
             attributes.update(additional_attributes)
@@ -353,8 +353,8 @@ class Folder(Item):
             preflight_check=False,
             preflight_expected_size=0,
             upload_using_accelerator=False,
-            file_created_at=None,
-            file_modified_at=None,
+            content_created_at=None,
+            content_modified_at=None,
             additional_attributes=None,
     ):
         """
@@ -392,13 +392,13 @@ class Folder(Item):
             Please notice that this is a premium feature, which might not be available to your app.
         :type upload_using_accelerator:
             `bool`
-        :param file_created_at:
+        :param content_created_at:
             The RFC-3339 datetime when the file was created.
-        :type file_created_at:
+        :type content_created_at:
             `unicode` or None
-        :param file_modified_at:
-            The RFC-3339 datetime when the file was last modified.
-        :type file_modified_at:
+        :param content_modified_at:
+            The RFC-3339 datetime when the file content was last modified.
+        :type content_modified_at:
             `unicode` or None
         :param additional_attributes:
             A dictionary containing attributes to add to the file that are not covered by other parameters.
@@ -419,8 +419,8 @@ class Folder(Item):
                 preflight_check,
                 preflight_expected_size=preflight_expected_size,
                 upload_using_accelerator=upload_using_accelerator,
-                file_created_at=file_created_at,
-                file_modified_at=file_modified_at,
+                content_created_at=content_created_at,
+                content_modified_at=content_modified_at,
                 additional_attributes=additional_attributes,
             )
 

--- a/test/unit/object/test_file.py
+++ b/test/unit/object/test_file.py
@@ -289,7 +289,7 @@ def test_update_contents(
 ):
     # pylint:disable=too-many-locals
     file_new_name = 'new_file_name'
-    file_modified_at = '1970-01-01T11:11:11+11:11'
+    content_modified_at = '1970-01-01T11:11:11+11:11'
     additional_attributes = {'attr': 123}
     expected_url = test_file.get_url('content').replace(API.BASE_API_URL, API.UPLOAD_URL)
     if upload_using_accelerator:
@@ -308,7 +308,7 @@ def test_update_contents(
             etag=etag,
             upload_using_accelerator=upload_using_accelerator,
             file_name=file_new_name,
-            file_modified_at=file_modified_at,
+            content_modified_at=content_modified_at,
             additional_attributes=additional_attributes,
         )
     else:
@@ -320,14 +320,14 @@ def test_update_contents(
                 etag=etag,
                 upload_using_accelerator=upload_using_accelerator,
                 file_name=file_new_name,
-                file_modified_at=file_modified_at,
+                content_modified_at=content_modified_at,
                 additional_attributes=additional_attributes,
             )
 
     mock_files = {'file': ('unused', mock_file_stream)}
     attributes = {
         'name': file_new_name,
-        'content_modified_at': file_modified_at,
+        'content_modified_at': content_modified_at,
     }
     # Using `update` to mirror the actual impl, since the attributes could otherwise come through in a different order
     # in Python 2 tests

--- a/test/unit/object/test_folder.py
+++ b/test/unit/object/test_folder.py
@@ -225,8 +225,8 @@ def test_upload(
 ):
     # pylint:disable=too-many-locals
     file_description = 'Test File Description'
-    file_created_at = '1970-01-01T00:00:00+00:00'
-    file_modified_at = '1970-01-01T11:11:11+11:11'
+    content_created_at = '1970-01-01T00:00:00+00:00'
+    content_modified_at = '1970-01-01T11:11:11+11:11'
     additional_attributes = {'attr': 123}
     expected_url = '{0}/files/content'.format(API.UPLOAD_URL)
     if upload_using_accelerator:
@@ -245,8 +245,8 @@ def test_upload(
             basename(mock_file_path),
             file_description,
             upload_using_accelerator=upload_using_accelerator,
-            file_created_at=file_created_at,
-            file_modified_at=file_modified_at,
+            content_created_at=content_created_at,
+            content_modified_at=content_modified_at,
             additional_attributes=additional_attributes,
         )
     else:
@@ -257,8 +257,8 @@ def test_upload(
                 mock_file_path,
                 file_description=file_description,
                 upload_using_accelerator=upload_using_accelerator,
-                file_created_at=file_created_at,
-                file_modified_at=file_modified_at,
+                content_created_at=content_created_at,
+                content_modified_at=content_modified_at,
                 additional_attributes=additional_attributes,
             )
 
@@ -267,8 +267,8 @@ def test_upload(
         'name': basename(mock_file_path),
         'parent': {'id': mock_object_id},
         'description': file_description,
-        'content_created_at': file_created_at,
-        'content_modified_at': file_modified_at,
+        'content_created_at': content_created_at,
+        'content_modified_at': content_modified_at,
     }
     # Using `update` to mirror the actual impl, since the attributes could otherwise come through in a different order
     # in Python 2 tests


### PR DESCRIPTION
Small iteration on #473; changing file attribute parameters to be the same as those in the API, as there's no good reason to differ from them.