### PR TITLE
Fix for `_get_retry_request_callable` so chunked uploads continue to work

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,11 +4,12 @@ Release History
 ---------------
 
 Next Release
-- Fixed bug in _get_retry_request_callable() introduced in release 2.7.0 which caused chunked uploads to fail
+++++++++
+- Fixed bug in `_get_retry_request_callable` introduced in release 2.7.0 which caused chunked uploads to fail
 
 2.7.0 (2020-01-16)
 ++++++++
-- Fixed bug in get_admin_events function which caused errors when the optional event_types parameter was omitted.
+- Fixed bug in `get_admin_events` function which caused errors when the optional `event_types` parameter was omitted.
 - Add marker based pagination for listing users.
 - Added support for more attribute parameters when uploading new files and new versions of existing files.
 - Combined preflight check and lookup of accelerator URL into a single request for uploads.

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,9 @@
 Release History
 ---------------
 
+Next Release
+- Fixed bug in _get_retry_request_callable() introduced in release 2.7.0 which caused chunked uploads to fail
+
 2.7.0 (2020-01-16)
 ++++++++
 - Fixed bug in get_admin_events function which caused errors when the optional event_types parameter was omitted.

--- a/boxsdk/session/session.py
+++ b/boxsdk/session/session.py
@@ -437,8 +437,11 @@ class Session(object):
         # pylint:disable=unused-argument
         data = kwargs.get('data', {})
         grant_type = None
-        if 'grant_type' in data:
-            grant_type = data['grant_type']
+        try:
+            if 'grant_type' in data:
+                grant_type = data['grant_type']
+        except TypeError:
+            pass
         code = network_response.status_code
         if (code in (202, 429) or code >= 500) and grant_type != self._JWT_GRANT_TYPE:
             return partial(


### PR DESCRIPTION
## Overview
Release of the Python SDK version 2.7.0 contained new logic in `_get_retry_request_callable` that prevented chunked uploads from working. 

## Details
The  new logic in the 2.7.0 release in `_get_retry_request_callable` method was reading the `data` dictionary passed in every request. However, for chunked uploads, `data` is a byte stream and not a dictionary, so the reading of the data fails. The fix in this PR is a simple try block that reads the `data` parameter when it is an object and doesn't when the `data` is a byte stream.