### PR TITLE
Feature/optional rate limiter

### DIFF
--- a/boxsdk/client/client.py
+++ b/boxsdk/client/client.py
@@ -27,8 +27,7 @@ class Client(Cloneable):
         oauth,
         session=None,
         rate_limited=True,
-        rate_limit=12,
-        rate_period=1,
+        rate_limit=12
     ):
         """
         :param oauth:
@@ -49,7 +48,7 @@ class Client(Cloneable):
             self._session = self.authorized_session_class(self._oauth, **session.get_constructor_kwargs())
 
         self._rate_limiter = (
-            RateLimiter(rate_limit, rate_period)
+            RateLimiter(rate_limit)
             if rate_limited
             else None
         )

--- a/boxsdk/client/client.py
+++ b/boxsdk/client/client.py
@@ -23,11 +23,11 @@ class Client(Cloneable):
     authorized_session_class = AuthorizedSession
 
     def __init__(
-        self,
-        oauth,
-        session=None,
-        rate_limited=True,
-        rate_limit=12
+            self,
+            oauth,
+            session=None,
+            rate_limited=True,
+            rate_limit=12
     ):
         """
         :param oauth:

--- a/boxsdk/client/client.py
+++ b/boxsdk/client/client.py
@@ -23,12 +23,12 @@ class Client(Cloneable):
     authorized_session_class = AuthorizedSession
 
     def __init__(
-            self,
-            oauth,
-            session=None,
-            rate_limited=True,
-            rate_limit=12,
-            rate_period=1,
+        self,
+        oauth,
+        session=None,
+        rate_limited=True,
+        rate_limit=12,
+        rate_period=1,
     ):
         """
         :param oauth:

--- a/boxsdk/client/rate_limiter.py
+++ b/boxsdk/client/rate_limiter.py
@@ -5,11 +5,9 @@ import time
 class RateLimiter(object):
     def __init__(
         self,
-        rate_limit=1,
-        rate_period=12
+        rate_limit=12
     ):
         self._rate_limit = rate_limit
-        self._rate_period = rate_period
         self._request_pool = collections.deque()
 
     def _limiter(self):
@@ -17,7 +15,7 @@ class RateLimiter(object):
             now = time.time()
 
             while self._request_pool:
-                if now - self._request_pool[0] > self._rate_period:
+                if now - self._request_pool[0] > 1:
                     self._request_pool.popleft()
                 else:
                     break

--- a/boxsdk/client/rate_limiter.py
+++ b/boxsdk/client/rate_limiter.py
@@ -35,5 +35,5 @@ class RateLimiter(object):
     def __enter__(self):
         return self._limiter()
 
-    def __exit__(self, exc_type, exc_val, exc_tb) -> None:
+    def __exit__(self, exc_type, exc_val, exc_tb):
         pass

--- a/boxsdk/client/rate_limiter.py
+++ b/boxsdk/client/rate_limiter.py
@@ -1,0 +1,39 @@
+import collections
+import time
+
+
+class RateLimiter(object):
+    def __init__(
+        self,
+        rate_limit=1,
+        rate_period=12
+    ):
+        self._rate_limit = rate_limit
+        self._rate_period = rate_period
+        self._request_pool = collections.deque()
+
+    def _limiter(self):
+        while True:
+            now = time.time()
+
+            while self._request_pool:
+                if now - self._request_pool[0] > self._rate_period:
+                    self._request_pool.popleft()
+                else:
+                    break
+
+            if len(self._request_pool) < self._rate_limit:
+                break
+
+            time.sleep(0.01)
+
+        self._request_pool.append(time.time())
+
+    def limit(self):
+        self._limiter()
+
+    def __enter__(self):
+        return self._limiter()
+
+    def __exit__(self, exc_type, exc_val, exc_tb) -> None:
+        pass

--- a/boxsdk/client/rate_limiter.py
+++ b/boxsdk/client/rate_limiter.py
@@ -4,8 +4,8 @@ import time
 
 class RateLimiter(object):
     def __init__(
-        self,
-        rate_limit=12
+            self,
+            rate_limit=12
     ):
         self._rate_limit = rate_limit
         self._request_pool = collections.deque()


### PR DESCRIPTION
- Add's rate limited context manager class to boxsdk.client.rate_limiter.RateLimiter
- Adds rate_limited (bool), rate_limit (int) to boxsdk.client.client.Client.__init__ kwargs. If rate_limited = True, sets Client instance attribute _rate_limiter = to a RateLimiter instance with the limit per seconds set = rate_limit kwarg.
- Updates boxsdk.client.client.Client.make_request to call the RateLimiter if Client._rate_limiter is not None.