### PR TITLE
Add support for token exchange using shared links

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,10 @@
 Release History
 ---------------
 
+Next Release
+++++++++
+- Added support for token exchange using shared links
+
 2.7.1 (2020-01-21)
 ++++++++
 - Fixed bug in `_get_retry_request_callable` introduced in release 2.7.0 which caused chunked uploads to fail

--- a/boxsdk/client/client.py
+++ b/boxsdk/client/client.py
@@ -1399,7 +1399,7 @@ class Client(Cloneable):
         )
 
     @api_call
-    def downscope_token(self, scopes, item=None, additional_data=None):
+    def downscope_token(self, scopes, item=None, shared_link=None, additional_data=None):
         """
         Generate a downscoped token for the provided file or folder with the provided scopes.
 
@@ -1412,6 +1412,11 @@ class Client(Cloneable):
             not be scoped down to just a single item.
         :type item:
             :class:`Item`
+        :param shared_link:
+            (Optional) The shared link to get a downscoped token for. If None, the resulting token will
+            not be scoped down to just a single item.
+        :type item:
+            `str`
         :param additional_data:
             (Optional) Key value pairs which can be used to add/update the default data values in the request.
         :type additional_data:
@@ -1431,6 +1436,8 @@ class Client(Cloneable):
         }
         if item:
             data['resource'] = item.get_url()
+        if shared_link:
+            data['box_shared_link'] = shared_link
         if additional_data:
             data.update(additional_data)
 

--- a/boxsdk/client/client.py
+++ b/boxsdk/client/client.py
@@ -1415,7 +1415,7 @@ class Client(Cloneable):
         :param shared_link:
             (Optional) The shared link to get a downscoped token for. If None, the resulting token will
             not be scoped down to just a single item.
-        :type item:
+        :type shared_link:
             `str`
         :param additional_data:
             (Optional) Key value pairs which can be used to add/update the default data values in the request.
@@ -1442,6 +1442,7 @@ class Client(Cloneable):
             data.update(additional_data)
 
         box_response = self._session.post(url, data=data)
+
         return TokenResponse(box_response.json())
 
     def clone(self, session=None):

--- a/boxsdk/client/client.py
+++ b/boxsdk/client/client.py
@@ -1,7 +1,6 @@
 # coding: utf-8
 # pylint: disable=too-many-lines
 from __future__ import unicode_literals, absolute_import
-
 import json
 
 from ..auth.oauth2 import TokenResponse

--- a/boxsdk/client/client.py
+++ b/boxsdk/client/client.py
@@ -1411,7 +1411,7 @@ class Client(Cloneable):
             (Optional) The file or folder to get a downscoped token for. If None and shared_link None, the resulting
             token will not be scoped down to just a single item.
         :type item:
-            :class:`Union[Item, str]`
+            :class:`Item`
         :param shared_link:
             (Optional) The shared link to get a downscoped token for. If None and item None, the resulting token
             will not be scoped down to just a single item.
@@ -1435,11 +1435,8 @@ class Client(Cloneable):
             'grant_type': 'urn:ietf:params:oauth:grant-type:token-exchange',
         }
 
-        if item and isinstance(item, Item):
+        if item:
             data['resource'] = item.get_url()
-        elif item and isinstance(item, str):
-            data['resource'] = item
-
         if shared_link:
             data['box_shared_link'] = shared_link
         if additional_data:

--- a/boxsdk/client/client.py
+++ b/boxsdk/client/client.py
@@ -14,7 +14,6 @@ from ..object.trash import Trash
 from ..pagination.limit_offset_based_object_collection import LimitOffsetBasedObjectCollection
 from ..pagination.marker_based_object_collection import MarkerBasedObjectCollection
 from ..util.shared_link import get_shared_link_header
-from ..object.item import Item
 
 
 class Client(Cloneable):

--- a/boxsdk/client/client.py
+++ b/boxsdk/client/client.py
@@ -14,6 +14,7 @@ from ..object.trash import Trash
 from ..pagination.limit_offset_based_object_collection import LimitOffsetBasedObjectCollection
 from ..pagination.marker_based_object_collection import MarkerBasedObjectCollection
 from ..util.shared_link import get_shared_link_header
+from ..object.item import Item
 
 
 class Client(Cloneable):
@@ -1407,13 +1408,13 @@ class Client(Cloneable):
         :type scopes:
             `Iterable` of :class:`TokenScope`
         :param item:
-            (Optional) The file or folder to get a downscoped token for. If None, the resulting token will
-            not be scoped down to just a single item.
+            (Optional) The file or folder to get a downscoped token for. If None and shared_link None, the resulting
+            token will not be scoped down to just a single item.
         :type item:
-            :class:`Item`
+            :class:`Union[Item, str]`
         :param shared_link:
-            (Optional) The shared link to get a downscoped token for. If None, the resulting token will
-            not be scoped down to just a single item.
+            (Optional) The shared link to get a downscoped token for. If None and item None, the resulting token
+            will not be scoped down to just a single item.
         :type shared_link:
             `str`
         :param additional_data:
@@ -1433,8 +1434,12 @@ class Client(Cloneable):
             'scope': ' '.join(scopes),
             'grant_type': 'urn:ietf:params:oauth:grant-type:token-exchange',
         }
-        if item:
+
+        if item and isinstance(item, Item):
             data['resource'] = item.get_url()
+        elif item and isinstance(item, str):
+            data['resource'] = item
+
         if shared_link:
             data['box_shared_link'] = shared_link
         if additional_data:

--- a/boxsdk/client/client.py
+++ b/boxsdk/client/client.py
@@ -1399,7 +1399,7 @@ class Client(Cloneable):
         )
 
     @api_call
-    def downscope_token(self, scopes, item=None, shared_link=None, additional_data=None):
+    def downscope_token(self, scopes, item=None, additional_data=None, shared_link=None):
         """
         Generate a downscoped token for the provided file or folder with the provided scopes.
 

--- a/test/unit/client/test_client.py
+++ b/test/unit/client/test_client.py
@@ -1123,19 +1123,6 @@ def test_downscope_token_sends_downscope_request(
     check_downscope_token_request(scopes, item_class, None, None, expected_data)
 
 
-def test_downscope_token_sends_downscope_request_with_no_item_shared_link_or_additional_data(
-        mock_client,
-        check_downscope_token_request,
-):
-    expected_data = {
-        'subject_token': mock_client.auth.access_token,
-        'subject_token_type': 'urn:ietf:params:oauth:token-type:access_token',
-        'scope': 'item_readwrite',
-        'grant_type': 'urn:ietf:params:oauth:grant-type:token-exchange',
-    }
-    check_downscope_token_request([TokenScope.ITEM_READWRITE], None, None, None, expected_data)
-
-
 def test_downscope_token_sends_downscope_request_with_shared_link(
         mock_client,
         check_downscope_token_request,

--- a/test/unit/client/test_client.py
+++ b/test/unit/client/test_client.py
@@ -1072,7 +1072,7 @@ def check_downscope_token_request(
         mock_object_id,
         make_mock_box_request,
 ):
-    def do_check(scopes, item_class, shared_link, additional_data, expected_data):
+    def do_check(scopes, item_class, additional_data, shared_link, expected_data):
         dummy_downscoped_token = 'dummy_downscoped_token'
         dummy_expires_in = 1234
         mock_box_response, _ = make_mock_box_request(
@@ -1082,7 +1082,7 @@ def check_downscope_token_request(
 
         item = item_class(mock_box_session, mock_object_id) if item_class else None
 
-        downscoped_token_response = mock_client.downscope_token(scopes, item, shared_link, additional_data)
+        downscoped_token_response = mock_client.downscope_token(scopes, item, additional_data, shared_link)
 
         assert downscoped_token_response.access_token == dummy_downscoped_token
         assert downscoped_token_response.expires_in == dummy_expires_in

--- a/test/unit/client/test_client.py
+++ b/test/unit/client/test_client.py
@@ -1123,7 +1123,7 @@ def test_downscope_token_sends_downscope_request(
     check_downscope_token_request(scopes, item_class, None, None, expected_data)
 
 
-def test_downscope_token_sends_downscope_request_with_no_item_shred_link_or_additional_data(
+def test_downscope_token_sends_downscope_request_with_no_item_shared_link_or_additional_data(
         mock_client,
         check_downscope_token_request,
 ):

--- a/test/unit/object/test_file.py
+++ b/test/unit/object/test_file.py
@@ -444,17 +444,22 @@ def test_update_contents_does_preflight_check_if_specified(
     ({'prevent_download': True}, {'is_download_prevented': True}),
     ({'expire_time': '2018-11-06T19:40:00-08:00'}, {
         'is_download_prevented': False,
-        'expires_at': '2018-11-06T19:40:00-08:00',
+        'expires_at': '2018-11-06T19:40:00-08:00'
     }),
 ])
 def test_lock(test_file, mock_box_session, mock_file_response, params, expected_data):
     expected_url = test_file.get_url()
     expected_body = {
         'lock': {
-            'type': 'lock',
+            'type': 'lock'
         }
     }
-    expected_body['lock'].update(expected_data)
+
+    if 'is_download_prevented' in expected_data.keys():
+        expected_body['lock']['is_download_prevented'] = expected_data['is_download_prevented']
+    if 'expires_at' in expected_data.keys():
+        expected_body['lock']['expires_at'] = expected_data['expires_at']
+
     mock_box_session.put.return_value = mock_file_response
     test_file.lock(**params)
     mock_box_session.put.assert_called_once_with(


### PR DESCRIPTION
- Adds shared_link kwarg to Client.downscope_token. If shared link is sent as an arg in the method call, the downscoped token will be scoped to the resource the shared link references.
- Adds unit test for Client.downscope_token with share_link sent as an arg, and shared_link and item not sent as an arg.