### PR TITLE
Add the ability to pass in a SHA1 value for file uploads

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,6 +6,7 @@ Release History
 Next Release
 ++++++++
 - Added support for token exchange using shared links
+- Added the ability to pass in a SHA1 value for file uploads
 
 2.7.1 (2020-01-21)
 ++++++++

--- a/boxsdk/object/file.py
+++ b/boxsdk/object/file.py
@@ -356,7 +356,7 @@ class File(Item):
         :type additional_attributes:
             `dict` or None
         :param sha1:
-            A sha1 checksum for a file.
+            A sha1 checksum for the new content.
         :type sha1:
             `unicode` or None
         :returns:

--- a/boxsdk/object/file.py
+++ b/boxsdk/object/file.py
@@ -202,6 +202,7 @@ class File(Item):
             file_name=None,
             content_modified_at=None,
             additional_attributes=None,
+            sha1=None
     ):
         """
         Upload a new version of a file, taking the contents from the given file stream.
@@ -244,6 +245,10 @@ class File(Item):
             A dictionary containing attributes to add to the file that are not covered by other parameters.
         :type additional_attributes:
             `dict` or None
+        :param sha1:
+            A content MD5 checksum for a file.
+        :type sha1:
+            `unicode` or None
         :returns:
             A new file object
         :rtype:
@@ -275,7 +280,13 @@ class File(Item):
 
         data = {'attributes': json.dumps(attributes)}
         files = {'file': ('unused', file_stream)}
-        headers = {'If-Match': etag} if etag is not None else None
+        headers = {}
+        if etag is not None:
+            headers['If-Match'] = etag
+        if sha1 is not None:
+            headers['Content-MD5'] = sha1
+        if not headers:
+            headers = None
         file_response = self._session.post(
             url,
             expect_json_response=False,
@@ -301,6 +312,7 @@ class File(Item):
             file_name=None,
             content_modified_at=None,
             additional_attributes=None,
+            sha1=None
     ):
         """Upload a new version of a file. The contents are taken from the given file path.
 
@@ -342,6 +354,10 @@ class File(Item):
             A dictionary containing attributes to add to the file that are not covered by other parameters.
         :type additional_attributes:
             `dict` or None
+        :param sha1:
+            A content MD5 checksum for a file.
+        :type sha1:
+            `unicode` or None
         :returns:
             A new file object
         :rtype:
@@ -360,6 +376,7 @@ class File(Item):
                 file_name=file_name,
                 content_modified_at=content_modified_at,
                 additional_attributes=additional_attributes,
+                sha1=sha1
             )
 
     @api_call

--- a/boxsdk/object/file.py
+++ b/boxsdk/object/file.py
@@ -246,7 +246,7 @@ class File(Item):
         :type additional_attributes:
             `dict` or None
         :param sha1:
-            A sha1 checksum for a file.
+            A sha1 checksum for the new content.
         :type sha1:
             `unicode` or None
         :returns:

--- a/boxsdk/object/file.py
+++ b/boxsdk/object/file.py
@@ -202,7 +202,7 @@ class File(Item):
             file_name=None,
             content_modified_at=None,
             additional_attributes=None,
-            sha1=None
+            sha1=None,
     ):
         """
         Upload a new version of a file, taking the contents from the given file stream.
@@ -313,7 +313,7 @@ class File(Item):
             file_name=None,
             content_modified_at=None,
             additional_attributes=None,
-            sha1=None
+            sha1=None,
     ):
         """Upload a new version of a file. The contents are taken from the given file path.
 
@@ -377,7 +377,7 @@ class File(Item):
                 file_name=file_name,
                 content_modified_at=content_modified_at,
                 additional_attributes=additional_attributes,
-                sha1=sha1
+                sha1=sha1,
             )
 
     @api_call

--- a/boxsdk/object/file.py
+++ b/boxsdk/object/file.py
@@ -246,7 +246,7 @@ class File(Item):
         :type additional_attributes:
             `dict` or None
         :param sha1:
-            A content MD5 checksum for a file.
+            A sha1 checksum for a file.
         :type sha1:
             `unicode` or None
         :returns:
@@ -284,6 +284,7 @@ class File(Item):
         if etag is not None:
             headers['If-Match'] = etag
         if sha1 is not None:
+            # The Content-MD5 field accepts sha1
             headers['Content-MD5'] = sha1
         if not headers:
             headers = None
@@ -355,7 +356,7 @@ class File(Item):
         :type additional_attributes:
             `dict` or None
         :param sha1:
-            A content MD5 checksum for a file.
+            A sha1 checksum for a file.
         :type sha1:
             `unicode` or None
         :returns:

--- a/boxsdk/object/folder.py
+++ b/boxsdk/object/folder.py
@@ -259,6 +259,8 @@ class Folder(Item):
             content_created_at=None,
             content_modified_at=None,
             additional_attributes=None,
+            sha1=None,
+            etag=None,
     ):
         """
         Upload a file to the folder.
@@ -306,6 +308,14 @@ class Folder(Item):
             A dictionary containing attributes to add to the file that are not covered by other parameters.
         :type additional_attributes:
             `dict` or None
+        :param sha1:
+            A sha1 checksum for a file.
+        :type sha1:
+            `unicode` or None
+        :param etag:
+            If specified, instruct the Box API to update the item only if the current version's etag matches.
+        :type etag:
+            `unicode` or None
         :returns:
             The newly uploaded file.
         :rtype:
@@ -336,7 +346,15 @@ class Folder(Item):
         files = {
             'file': ('unused', file_stream),
         }
-        file_response = self._session.post(url, data=data, files=files, expect_json_response=False).json()
+        headers = {}
+        if etag is not None:
+            headers['If-Match'] = etag
+        if sha1 is not None:
+            # The Content-MD5 field accepts sha1
+            headers['Content-MD5'] = sha1
+        if not headers:
+            headers = None
+        file_response = self._session.post(url, data=data, files=files, expect_json_response=False, headers=headers).json()
         if 'entries' in file_response:
             file_response = file_response['entries'][0]
         return self.translator.translate(
@@ -356,6 +374,8 @@ class Folder(Item):
             content_created_at=None,
             content_modified_at=None,
             additional_attributes=None,
+            sha1=None,
+            etag=None,
     ):
         """
         Upload a file to the folder.
@@ -404,6 +424,14 @@ class Folder(Item):
             A dictionary containing attributes to add to the file that are not covered by other parameters.
         :type additional_attributes:
             `dict` or None
+        :param sha1:
+            A sha1 checksum for a file.
+        :type sha1:
+            `unicode` or None
+        :param etag:
+            If specified, instruct the Box API to update the item only if the current version's etag matches.
+        :type etag:
+            `unicode` or None
         :returns:
             The newly uploaded file.
         :rtype:
@@ -422,6 +450,8 @@ class Folder(Item):
                 content_created_at=content_created_at,
                 content_modified_at=content_modified_at,
                 additional_attributes=additional_attributes,
+                sha1=sha1,
+                etag=etag,
             )
 
     @api_call

--- a/boxsdk/object/folder.py
+++ b/boxsdk/object/folder.py
@@ -309,7 +309,7 @@ class Folder(Item):
         :type additional_attributes:
             `dict` or None
         :param sha1:
-            A sha1 checksum for a file.
+            A sha1 checksum for the file.
         :type sha1:
             `unicode` or None
         :param etag:
@@ -425,7 +425,7 @@ class Folder(Item):
         :type additional_attributes:
             `dict` or None
         :param sha1:
-            A sha1 checksum for a file.
+            A sha1 checksum for the new content.
         :type sha1:
             `unicode` or None
         :param etag:

--- a/test/unit/object/conftest.py
+++ b/test/unit/object/conftest.py
@@ -270,9 +270,23 @@ def if_match_header(etag):
 def if_none_match_header(etag):
     return {'If-None-Match': etag} if etag is not None else None
 
+@pytest.fixture()
+def if_match_sha1_header(etag, sha1):
+    headers = {}
+    if etag is not None:
+        headers['If-Match'] = etag
+    if sha1 is not None:
+        headers['Content-MD5'] = sha1
+    if not headers:
+        headers = None
+    return headers
 
 @pytest.fixture(params=[None, 'etag'])
 def etag(request):
+    return request.param
+
+@pytest.fixture(params=[None, 'cf23df2207d99a74fbe169e3eba035e633b65d94'])
+def sha1(request):
     return request.param
 
 

--- a/test/unit/object/conftest.py
+++ b/test/unit/object/conftest.py
@@ -270,6 +270,7 @@ def if_match_header(etag):
 def if_none_match_header(etag):
     return {'If-None-Match': etag} if etag is not None else None
 
+
 @pytest.fixture()
 def if_match_sha1_header(etag, sha1):
     headers = {}
@@ -281,9 +282,11 @@ def if_match_sha1_header(etag, sha1):
         headers = None
     return headers
 
+
 @pytest.fixture(params=[None, 'etag'])
 def etag(request):
     return request.param
+
 
 @pytest.fixture(params=[None, 'cf23df2207d99a74fbe169e3eba035e633b65d94'])
 def sha1(request):

--- a/test/unit/object/test_file.py
+++ b/test/unit/object/test_file.py
@@ -280,11 +280,12 @@ def test_update_contents(
         mock_upload_response,
         mock_file_path,
         etag,
+        sha1,
         upload_using_accelerator,
         mock_accelerator_response_for_update,
         mock_accelerator_upload_url_for_update,
         upload_using_accelerator_fails,
-        if_match_header,
+        if_match_sha1_header,
         is_stream,
 ):
     # pylint:disable=too-many-locals
@@ -310,6 +311,7 @@ def test_update_contents(
             file_name=file_new_name,
             content_modified_at=content_modified_at,
             additional_attributes=additional_attributes,
+            sha1=sha1
         )
     else:
         mock_file = mock_open(read_data=mock_content_response.content)
@@ -322,6 +324,7 @@ def test_update_contents(
                 file_name=file_new_name,
                 content_modified_at=content_modified_at,
                 additional_attributes=additional_attributes,
+                sha1=sha1
             )
 
     mock_files = {'file': ('unused', mock_file_stream)}
@@ -338,7 +341,7 @@ def test_update_contents(
         expect_json_response=False,
         files=mock_files,
         data=data,
-        headers=if_match_header,
+        headers=if_match_sha1_header,
     )
     assert isinstance(new_file, File)
     assert new_file.object_id == test_file.object_id

--- a/test/unit/object/test_file.py
+++ b/test/unit/object/test_file.py
@@ -311,7 +311,7 @@ def test_update_contents(
             file_name=file_new_name,
             content_modified_at=content_modified_at,
             additional_attributes=additional_attributes,
-            sha1=sha1
+            sha1=sha1,
         )
     else:
         mock_file = mock_open(read_data=mock_content_response.content)
@@ -324,7 +324,7 @@ def test_update_contents(
                 file_name=file_new_name,
                 content_modified_at=content_modified_at,
                 additional_attributes=additional_attributes,
-                sha1=sha1
+                sha1=sha1,
             )
 
     mock_files = {'file': ('unused', mock_file_stream)}

--- a/test/unit/object/test_folder.py
+++ b/test/unit/object/test_folder.py
@@ -222,6 +222,9 @@ def test_upload(
         mock_new_upload_accelerator_url,
         upload_using_accelerator_fails,
         is_stream,
+        etag,
+        sha1,
+        if_match_sha1_header
 ):
     # pylint:disable=too-many-locals
     file_description = 'Test File Description'
@@ -248,6 +251,8 @@ def test_upload(
             content_created_at=content_created_at,
             content_modified_at=content_modified_at,
             additional_attributes=additional_attributes,
+            sha1=sha1,
+            etag=etag,
         )
     else:
         mock_file = mock_open(read_data=mock_content_response.content)
@@ -260,6 +265,8 @@ def test_upload(
                 content_created_at=content_created_at,
                 content_modified_at=content_modified_at,
                 additional_attributes=additional_attributes,
+                sha1=sha1,
+                etag=etag,
             )
 
     mock_files = {'file': ('unused', mock_file_stream)}
@@ -274,7 +281,7 @@ def test_upload(
     # in Python 2 tests
     attributes.update(additional_attributes)
     data = {'attributes': json.dumps(attributes)}
-    mock_box_session.post.assert_called_once_with(expected_url, expect_json_response=False, files=mock_files, data=data)
+    mock_box_session.post.assert_called_once_with(expected_url, expect_json_response=False, files=mock_files, data=data, headers=if_match_sha1_header)
     assert isinstance(new_file, File)
     assert new_file.object_id == mock_object_id
     assert 'id' in new_file

--- a/test/unit/object/test_folder.py
+++ b/test/unit/object/test_folder.py
@@ -224,7 +224,7 @@ def test_upload(
         is_stream,
         etag,
         sha1,
-        if_match_sha1_header
+        if_match_sha1_header,
 ):
     # pylint:disable=too-many-locals
     file_description = 'Test File Description'


### PR DESCRIPTION
Added the ability to pass in a SHA1 value for file uploads. It will sent in the headers to the API with the following key `Content-MD5`.