### PR TITLE
Fix bug with updating a collaboration role to owner

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,6 +6,7 @@ Release History
 Next Release
 ++++++++
 - Allow ints to be passed in as item IDs
+- Fix bug with updating a collaboration role to owner
 
 2.9.0 (2020-06-23)
 ++++++++

--- a/boxsdk/object/base_object.py
+++ b/boxsdk/object/base_object.py
@@ -125,10 +125,13 @@ class BaseObject(BaseEndpoint, BaseAPIJSONObject):
         """
         url = self.get_url()
         box_response = self._session.put(url, data=json.dumps(data), params=params, headers=headers, **kwargs)
-        return self.translator.translate(
-            session=self._session,
-            response_object=box_response.json(),
-        )
+        if 'expect_json_response' in kwargs and not kwargs['expect_json_response']:
+            return box_response.ok
+        else:
+            return self.translator.translate(
+                session=self._session,
+                response_object=box_response.json(),
+            )
 
     @api_call
     def delete(self, params=None, headers=None):

--- a/boxsdk/object/base_object.py
+++ b/boxsdk/object/base_object.py
@@ -123,6 +123,7 @@ class BaseObject(BaseEndpoint, BaseAPIJSONObject):
         :rtype:
             :class:`BaseObject`
         """
+        # pylint:disable=no-else-return
         url = self.get_url()
         box_response = self._session.put(url, data=json.dumps(data), params=params, headers=headers, **kwargs)
         if 'expect_json_response' in kwargs and not kwargs['expect_json_response']:

--- a/boxsdk/object/collaboration.py
+++ b/boxsdk/object/collaboration.py
@@ -58,7 +58,10 @@ class Collaboration(BaseObject):
             data['role'] = role
         if status:
             data['status'] = status
-        return super(Collaboration, self).update_info(data=data)
+        if role == CollaborationRole.OWNER:
+            return super(Collaboration, self).update_info(data=data, expect_json_response=False)
+        else:
+            return super(Collaboration, self).update_info(data=data)
 
     @api_call
     def accept(self):

--- a/boxsdk/object/collaboration.py
+++ b/boxsdk/object/collaboration.py
@@ -52,7 +52,7 @@ class Collaboration(BaseObject):
         :raises:
             :class:`BoxAPIException` if current user doesn't have permissions to edit the collaboration.
         """
-        # pylint:disable=arguments-differ
+        # pylint:disable=arguments-differ,no-else-return
         data = {}
         if role:
             data['role'] = role

--- a/test/unit/object/test_collaboration.py
+++ b/test/unit/object/test_collaboration.py
@@ -36,6 +36,26 @@ def test_update_info_returns_the_correct_response(
     assert isinstance(update_response, test_collaboration.__class__)
     assert update_response.object_id == test_collaboration.object_id
 
+@pytest.mark.parametrize('data', [
+    {'role': CollaborationRole.OWNER, 'status': CollaborationStatus.ACCEPTED},
+])
+def test_update_info_returns_204(
+        test_collaboration,
+        mock_box_session,
+        data):
+    # pylint:disable=protected-access
+    expected_url = test_collaboration.get_url()
+    mock_box_session.put.return_value.ok = True
+    is_success = test_collaboration.update_info(**data)
+    mock_box_session.put.assert_called_once_with(
+        expected_url,
+        data=json.dumps(data),
+        expect_json_response=False,
+        headers=None,
+        params=None,
+    )
+    assert is_success is True
+
 
 def test_accept_pending_collaboration(test_collaboration, mock_box_session):
     # pylint:disable=protected-access

--- a/test/unit/object/test_collaboration.py
+++ b/test/unit/object/test_collaboration.py
@@ -56,7 +56,6 @@ def test_update_info_returns_204(
     )
     assert is_success is True
 
-
 def test_accept_pending_collaboration(test_collaboration, mock_box_session):
     # pylint:disable=protected-access
     new_status = 'accepted'

--- a/test/unit/object/test_collaboration.py
+++ b/test/unit/object/test_collaboration.py
@@ -36,14 +36,12 @@ def test_update_info_returns_the_correct_response(
     assert isinstance(update_response, test_collaboration.__class__)
     assert update_response.object_id == test_collaboration.object_id
 
-@pytest.mark.parametrize('data', [
-    {'role': CollaborationRole.OWNER, 'status': CollaborationStatus.ACCEPTED},
-])
+
 def test_update_info_returns_204(
         test_collaboration,
-        mock_box_session,
-        data):
+        mock_box_session):
     # pylint:disable=protected-access
+    data = {'role': CollaborationRole.OWNER, 'status': CollaborationStatus.ACCEPTED}
     expected_url = test_collaboration.get_url()
     mock_box_session.put.return_value.ok = True
     is_success = test_collaboration.update_info(**data)
@@ -55,6 +53,7 @@ def test_update_info_returns_204(
         params=None,
     )
     assert is_success is True
+
 
 def test_accept_pending_collaboration(test_collaboration, mock_box_session):
     # pylint:disable=protected-access


### PR DESCRIPTION
This is to address issue #528. When a collaboration role is updated to an owner, the endpoint returns a 204 with no JSON response instead of the 200 with a JSON response that all other updates return. The SDK was throwing an error when a 204 is returned and this PR addresses the issue.

Wrote an automated test and did manual testing.