### PR TITLE
Fix HISTORY links to use correct repo

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -8,14 +8,14 @@ Release History
 
 **New Features and Enhancements:**
 
-- Add support for `copyInstanceOnItemCopy` field for metadata templates (`#546 <https://github.com/box/box-ios-sdk/pull/546>`_)
-- Allow creating tasks with the `action` and `completion_rule` parameters (`#544 <https://github.com/box/box-ios-sdk/pull/544>`_)
-- Add zip functionality (`#539 <https://github.com/box/box-ios-sdk/pull/539>`_)
+- Add support for `copyInstanceOnItemCopy` field for metadata templates (`#546 <https://github.com/box/box-python-sdk/pull/546>`_)
+- Allow creating tasks with the `action` and `completion_rule` parameters (`#544 <https://github.com/box/box-python-sdk/pull/544>`_)
+- Add zip functionality (`#539 <https://github.com/box/box-python-sdk/pull/539>`_)
 
 **Bug Fixes:**
 
-- Fix bug with updating a collaboration role to owner (`#536 <https://github.com/box/box-ios-sdk/pull/536>`_)
-- Allow ints to be passed in as item IDs (`#530 <https://github.com/box/box-ios-sdk/pull/530>`_)
+- Fix bug with updating a collaboration role to owner (`#536 <https://github.com/box/box-python-sdk/pull/536>`_)
+- Allow ints to be passed in as item IDs (`#530 <https://github.com/box/box-python-sdk/pull/530>`_)
 
 2.9.0 (2020-06-23)
 ++++++++


### PR DESCRIPTION
Some copypasta had them using the ios repo, rather than Python. I was confused for a little bit trying to understand why there was so much C in the python sdk.