### PR TITLE
dependencies: Limiting cryptography library version to <3.5.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ def main():
         'wrapt>=1.10.1',
     ]
     redis_requires = ['redis>=2.10.3']
-    jwt_requires = ['pyjwt>=1.3.0', 'cryptography>=3']
+    jwt_requires = ['pyjwt>=1.3.0', 'cryptography>=3, <3.5.0']
     extra_requires = defaultdict(list)
     extra_requires.update({'jwt': jwt_requires, 'redis': redis_requires, 'all': jwt_requires + redis_requires})
     conditional_dependencies = {


### PR DESCRIPTION
This limit is set, because >=3.5.0 versions require Rust