### PR TITLE
docs: Fix spelling error in changelog

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -9,7 +9,7 @@ Release History
 **New Features and Enhancements:**
 
 - Add `admin_logs_streaming` support for events stream (`#623 <https://github.com/box/box-python-sdk/pull/623>`_)
-- Add `vanity_name` param for creating shared link to a file or folder (`#637 <https://github.com/box/box-python-sdk/pull/637>`_)
+- Add `vanity_name` parameter for creating shared link to a file or folder (`#637 <https://github.com/box/box-python-sdk/pull/637>`_)
 - Add getting files and file versions under retention for a retention policy assignment (`#633 <https://github.com/box/box-python-sdk/pull/633>`_)
 - Support base item operations for WebLink class (`#639 <https://github.com/box/box-python-sdk/pull/639>`_)
 


### PR DESCRIPTION
Failing build: https://github.com/box/box-developer-changelog/actions/runs/1554484687