### PR TITLE
feat!: Change some methods signatures to accept keyword only arguments

### DIFF
--- a/boxsdk/object/base_endpoint.py
+++ b/boxsdk/object/base_endpoint.py
@@ -34,17 +34,14 @@ class BaseEndpoint(Cloneable):
         """
         return self._session.translator
 
-    def get_url(self, endpoint: str, *args: Any) -> str:
+    def get_url(self, *args: Any) -> str:
         """
         Return the URL used to access the endpoint.
 
-        :param endpoint:
-            The name of the endpoint.
         :param args:
-            Additional parts of the endpoint URL.
+            Parts of the endpoint URL.
         """
-        # pylint:disable=no-self-use
-        return self._session.get_url(endpoint, *args)
+        return self._session.get_url(*args)
 
     def clone(self, session: 'Session' = None) -> 'BaseEndpoint':
         """

--- a/boxsdk/object/base_item.py
+++ b/boxsdk/object/base_item.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
 class BaseItem(BaseObject):
 
     @api_call
-    def copy(self, parent_folder: 'Folder', name: str = None) -> 'BaseItem':
+    def copy(self, *, parent_folder: 'Folder', name: str = None, **_kwargs) -> 'BaseItem':
         """Copy the item to the given folder.
 
         :param parent_folder:
@@ -52,7 +52,7 @@ class BaseItem(BaseObject):
         }
         if name is not None:
             data['name'] = name
-        return self.update_info(data)
+        return self.update_info(data=data)
 
     @api_call
     def rename(self, name: str) -> 'BaseItem':
@@ -65,7 +65,7 @@ class BaseItem(BaseObject):
         data = {
             'name': name,
         }
-        return self.update_info(data)
+        return self.update_info(data=data)
 
     @api_call
     def create_shared_link(self, **kwargs: Any) -> Any:
@@ -102,7 +102,7 @@ class BaseItem(BaseObject):
         data = {'shared_link': shared_link}
         update_info_kwargs = {'etag': kwargs.get('etag')} if kwargs.get('etag') is not None else {}
 
-        return self.update_info(data, **update_info_kwargs)
+        return self.update_info(data=data, **update_info_kwargs)
 
     @api_call
     def get_shared_link(self, **kwargs: Any) -> str:
@@ -131,7 +131,7 @@ class BaseItem(BaseObject):
         data = {'shared_link': None}
         update_info_kwargs = {'etag': kwargs.get('etag')} if kwargs.get('etag') is not None else {}
 
-        item = self.update_info(data, **update_info_kwargs)
+        item = self.update_info(data=data, **update_info_kwargs)
         return item.shared_link is None  # pylint:disable=no-member
 
     @api_call
@@ -149,7 +149,7 @@ class BaseItem(BaseObject):
         data = {
             'collections': collections
         }
-        return self.update_info(data)
+        return self.update_info(data=data)
 
     @api_call
     def remove_from_collection(self, collection: 'Collection') -> 'BaseItem':
@@ -166,7 +166,7 @@ class BaseItem(BaseObject):
         data = {
             'collections': updated_collections
         }
-        return self.update_info(data)
+        return self.update_info(data=data)
 
     @staticmethod
     def validate_item_id(item_id: Union[str, int]) -> None:

--- a/boxsdk/object/collaboration.py
+++ b/boxsdk/object/collaboration.py
@@ -1,5 +1,5 @@
 # coding: utf-8
-from typing import Optional
+from typing import Optional, Any
 
 from boxsdk.object.base_object import BaseObject
 from boxsdk.util.text_enum import TextEnum
@@ -34,8 +34,10 @@ class Collaboration(BaseObject):
     @api_call
     def update_info(
             self,
+            *,
             role: Optional[CollaborationRole] = None,
-            status: Optional[CollaborationStatus] = None
+            status: Optional[CollaborationStatus] = None,
+            **kwargs: Any
     ) -> 'BaseObject':
         """Edit an existing collaboration on Box
 
@@ -56,9 +58,9 @@ class Collaboration(BaseObject):
         if status:
             data['status'] = status
         if role == CollaborationRole.OWNER:
-            return super().update_info(data=data, expect_json_response=False)
+            return super().update_info(data=data, expect_json_response=False, **kwargs)
 
-        return super().update_info(data=data)
+        return super().update_info(data=data, **kwargs)
 
     @api_call
     def accept(self) -> 'BaseObject':

--- a/boxsdk/object/comment.py
+++ b/boxsdk/object/comment.py
@@ -47,4 +47,4 @@ class Comment(BaseObject):
             The content of the reply comment.
         """
         data = self.construct_params_from_message(message)
-        return self.update_info(data)
+        return self.update_info(data=data)

--- a/boxsdk/object/events.py
+++ b/boxsdk/object/events.py
@@ -60,7 +60,6 @@ class Events(BaseEndpoint):
 
     def get_url(self, *args: Any) -> str:
         """Base class override."""
-        # pylint:disable=arguments-differ
         return super().get_url('events', *args)
 
     @api_call

--- a/boxsdk/object/file.py
+++ b/boxsdk/object/file.py
@@ -344,7 +344,7 @@ class File(Item):
         }
         if expire_time is not None:
             data['lock']['expires_at'] = expire_time
-        return self.update_info(data)
+        return self.update_info(data=data)
 
     @api_call
     def unlock(self) -> 'File':
@@ -355,7 +355,7 @@ class File(Item):
             A new :class:`File` instance reflecting that the file has been unlocked.
         """
         data = {'lock': None}
-        return self.update_info(data)
+        return self.update_info(data=data)
 
     @api_call
     def get_shared_link_download_url(
@@ -681,7 +681,14 @@ class File(Item):
         return b''
 
     @api_call
-    def copy(self, parent_folder: 'Folder', name: Optional[str] = None, file_version: 'FileVersion' = None) -> 'File':
+    def copy(
+            self,
+            *,
+            parent_folder: 'Folder',
+            name: Optional[str] = None,
+            file_version: 'FileVersion' = None,
+            **_kwargs
+    ) -> 'File':
         # pylint: disable=arguments-differ
         """Copy the item to the given folder.
 
@@ -694,6 +701,7 @@ class File(Item):
         :returns:
             The copy of the file
         """
+        # pylint: disable=arguments-differ
         url = self.get_url('copy')
         data = {
             'parent': {'id': parent_folder.object_id}

--- a/boxsdk/object/folder.py
+++ b/boxsdk/object/folder.py
@@ -503,7 +503,13 @@ class Folder(Item):
         )
 
     @api_call
-    def delete(self, recursive: bool = True, etag: Optional[str] = None) -> bool:
+    def delete(
+            self,
+            *,
+            recursive: bool = True,
+            etag: Optional[str] = None,
+            **kwargs
+    ) -> bool:
         """Base class override. Delete the folder.
 
         :param recursive:
@@ -515,7 +521,7 @@ class Folder(Item):
         :raises: :class:`BoxAPIException` if the specified etag doesn't match the latest version of the folder.
         """
         # pylint:disable=arguments-differ,arguments-renamed
-        return super().delete({'recursive': recursive}, etag)
+        return super().delete(params={'recursive': recursive}, etag=etag, **kwargs)
 
     @api_call
     def get_metadata_cascade_policies(

--- a/boxsdk/object/item.py
+++ b/boxsdk/object/item.py
@@ -99,7 +99,7 @@ class Item(BaseItem):
         return response_json.get('upload_url', None)
 
     @api_call
-    def update_info(self, data: dict, etag: Optional[str] = None) -> 'Item':
+    def update_info(self, *, data: dict, etag: Optional[str] = None, **kwargs: Any) -> 'Item':
         """
         Baseclass override.
         :param data:
@@ -120,10 +120,10 @@ class Item(BaseItem):
         # pylint:disable=arguments-differ
         self.validate_item_id(self._object_id)
         headers = {'If-Match': etag} if etag is not None else None
-        return super().update_info(data, headers=headers)
+        return super().update_info(data=data, headers=headers, **kwargs)
 
     @api_call
-    def get(self, fields: Iterable[str] = None, etag: Optional[str] = None) -> 'Item':
+    def get(self, *, fields: Iterable[str] = None, etag: Optional[str] = None, **kwargs) -> 'Item':
         """
         Base class override.
 
@@ -138,11 +138,12 @@ class Item(BaseItem):
         # pylint:disable=arguments-differ,arguments-renamed
         self.validate_item_id(self._object_id)
         headers = {'If-None-Match': etag} if etag is not None else None
-        return super().get(fields=fields, headers=headers)
+        return super().get(fields=fields, headers=headers, **kwargs)
 
     @api_call
     def create_shared_link(
             self,
+            *,
             access: Optional[str] = None,
             etag: Optional[str] = None,
             unshared_at: Optional[str] = SDK_VALUE_NOT_SET,
@@ -198,6 +199,7 @@ class Item(BaseItem):
     @api_call
     def get_shared_link(
             self,
+            *,
             access: Optional[str] = None,
             etag: Optional[str] = None,
             unshared_at: Optional[str] = SDK_VALUE_NOT_SET,
@@ -248,7 +250,7 @@ class Item(BaseItem):
         )
 
     @api_call
-    def remove_shared_link(self, etag: Optional[str] = None, **kwargs: Any) -> bool:
+    def remove_shared_link(self, *, etag: Optional[str] = None, **kwargs: Any) -> bool:
         """
         Baseclass override.
 
@@ -264,7 +266,7 @@ class Item(BaseItem):
         return super().remove_shared_link(etag=etag)
 
     @api_call
-    def delete(self, params: dict = None, etag: Optional[str] = None) -> bool:
+    def delete(self, *, params: dict = None, etag: Optional[str] = None, **kwargs) -> bool:
         """Delete the item.
 
         :param params:
@@ -278,7 +280,7 @@ class Item(BaseItem):
         # pylint:disable=arguments-differ,arguments-renamed
         self.validate_item_id(self._object_id)
         headers = {'If-Match': etag} if etag is not None else None
-        return super().delete(params, headers)
+        return super().delete(params=params, headers=headers, **kwargs)
 
     def metadata(self, scope: str = 'global', template: str = 'properties') -> Metadata:
         """

--- a/boxsdk/object/metadata.py
+++ b/boxsdk/object/metadata.py
@@ -103,7 +103,6 @@ class Metadata(BaseEndpoint):
 
     def get_url(self, *args: Any) -> str:
         """ Base class override. """
-        # pylint:disable=arguments-differ
         return self._object.get_url('metadata', self._scope, self._template)
 
     @staticmethod

--- a/boxsdk/object/metadata_template.py
+++ b/boxsdk/object/metadata_template.py
@@ -1,6 +1,5 @@
 # coding: utf-8
 
-import json
 from typing import TYPE_CHECKING, List, Optional, Iterable, Any
 from .base_object import BaseObject
 from ..util.api_call_decorator import api_call
@@ -269,7 +268,7 @@ class MetadataTemplate(BaseObject):
         return MetadataTemplateUpdate()
 
     @api_call
-    def update_info(self, updates: MetadataTemplateUpdate) -> 'MetadataTemplate':
+    def update_info(self, *, updates: MetadataTemplateUpdate, **kwargs) -> 'MetadataTemplate':
         # pylint: disable=arguments-differ
         """
         Update a metadata template with a set of update operations.
@@ -279,9 +278,5 @@ class MetadataTemplate(BaseObject):
         :returns:
             The updated metadata template object
         """
-        url = self.get_url()
-        response = self._session.put(url, data=json.dumps(updates.json())).json()
-        return self.translator.translate(
-            session=self._session,
-            response_object=response,
-        )
+        # pylint: disable=arguments-differ
+        return super().update_info(data=updates.json(), **kwargs)

--- a/boxsdk/object/search.py
+++ b/boxsdk/object/search.py
@@ -131,8 +131,7 @@ class Search(BaseEndpoint):
         :return:
             The search endpoint URL.
         """
-        # pylint:disable=arguments-differ
-        return super().get_url('search')
+        return super().get_url('search', *args)
 
     @staticmethod
     def start_metadata_filters() -> MetadataSearchFilters:
@@ -275,7 +274,6 @@ class Search(BaseEndpoint):
             limit: int = None,
             fields: Iterable[Optional[str]] = None
     ) -> 'BoxObjectCollection':
-        # pylint: disable=arguments-differ
         """Query Box items by their metadata.
 
         :param from_template:

--- a/boxsdk/object/storage_policy.py
+++ b/boxsdk/object/storage_policy.py
@@ -44,7 +44,7 @@ class StoragePolicy(BaseObject):
                 'id': self.object_id,
             },
         }
-        return assignment.update_info(update_object)
+        return assignment.update_info(data=update_object)
 
     def create_assignment(self, user: 'User') -> 'StoragePolicyAssignment':
         """

--- a/boxsdk/object/terms_of_service.py
+++ b/boxsdk/object/terms_of_service.py
@@ -109,5 +109,5 @@ class TermsOfService(BaseObject):
         except BoxAPIException as err:
             if err.status == 409:
                 user_status = self.get_user_status(user)
-                translated_response = user_status.update_info({'is_accepted': is_accepted})
+                translated_response = user_status.update_info(data={'is_accepted': is_accepted})
         return translated_response

--- a/boxsdk/object/user.py
+++ b/boxsdk/object/user.py
@@ -174,7 +174,7 @@ class User(BaseObject):
         return response.content
 
     @api_call
-    def delete(self, notify: bool = True, force: bool = False) -> bool:
+    def delete(self, *, notify: bool = True, force: bool = False, **kwargs) -> bool:
         # pylint: disable=arguments-differ,arguments-renamed
         """
         Delete a user's account.  This user will no longer be able to access Box.
@@ -190,4 +190,4 @@ class User(BaseObject):
             'notify': notify,
             'force': force,
         }
-        return super().delete(params=params)
+        return super().delete(params=params, **kwargs)

--- a/boxsdk/object/web_link.py
+++ b/boxsdk/object/web_link.py
@@ -14,6 +14,7 @@ class WebLink(BaseItem):
     @api_call
     def create_shared_link(
             self,
+            *,
             access: Optional[str] = None,
             unshared_at: Optional[str] = SDK_VALUE_NOT_SET,
             password: Optional[str] = None,
@@ -54,6 +55,7 @@ class WebLink(BaseItem):
     @api_call
     def get_shared_link(
             self,
+            *,
             access: Optional[str] = None,
             unshared_at: Optional[str] = SDK_VALUE_NOT_SET,
             password: Optional[str] = None,

--- a/test/functional/test_events.py
+++ b/test/functional/test_events.py
@@ -80,12 +80,12 @@ def test_rename_folder_causes_rename_event(box_events, created_subfolder, assert
 
 def test_copy_file_causes_copy_event(box_events, copy_target, uploaded_file, assert_event):
     # pylint:disable=redefined-outer-name
-    assert_event(lambda: uploaded_file.copy(copy_target), 'ITEM_COPY', box_events.get_latest_stream_position())
+    assert_event(lambda: uploaded_file.copy(parent_folder=copy_target), 'ITEM_COPY', box_events.get_latest_stream_position())
 
 
 def test_copy_folder_causes_copy_event(box_events, copy_target, created_subfolder, assert_event):
     # pylint:disable=redefined-outer-name
-    assert_event(lambda: created_subfolder.copy(copy_target), 'ITEM_COPY', box_events.get_latest_stream_position())
+    assert_event(lambda: created_subfolder.copy(parent_folder=copy_target), 'ITEM_COPY', box_events.get_latest_stream_position())
 
 
 @pytest.mark.xfail(reason='trash event has no source')

--- a/test/functional/test_item_info.py
+++ b/test/functional/test_item_info.py
@@ -17,7 +17,7 @@ def test_create_file_then_update_info(uploaded_file):
 
 def _test_create_then_update_info(item):
     updated_name = f'updated_{item.name}'
-    updated_item = item.update_info({'name': updated_name})
+    updated_item = item.update_info(data={'name': updated_name})
     assert updated_item.name == updated_name
     assert item.get().name == updated_name
 
@@ -79,7 +79,7 @@ def test_create_file_then_copy(box_client, uploaded_file):
 def _test_create_then_copy(box_client, item):
     # pylint:disable=redefined-outer-name
     copy_target = box_client.folder('0').create_subfolder('copy target')
-    copied_item = item.copy(copy_target)
+    copied_item = item.copy(parent_folder=copy_target)
     item = item.get()
     copied_item = copied_item.get()
     assert item.id != copied_item.id

--- a/test/unit/object/test_base_item.py
+++ b/test/unit/object/test_base_item.py
@@ -60,7 +60,7 @@ def test_copy_base_item(test_base_item_and_response, mock_box_session, test_fold
     }
     expected_body.update(expected_data)
     mock_box_session.post.return_value = mock_item_response
-    copy_response = test_item.copy(test_folder, **params)
+    copy_response = test_item.copy(parent_folder=test_folder, **params)
     mock_box_session.post.assert_called_once_with(expected_url, data=json.dumps(expected_body))
     assert isinstance(copy_response, test_item.__class__)
 

--- a/test/unit/object/test_base_object.py
+++ b/test/unit/object/test_base_object.py
@@ -45,7 +45,7 @@ def test_update_info(test_object_and_response, mock_box_session, params, headers
     expected_url = test_object.get_url()
     mock_box_session.put.return_value = mock_object_response
     data = {'foo': 'bar', 'baz': {'foo': 'bar'}, 'num': 4}
-    update_response = BaseObject.update_info(test_object, data, params=params, headers=headers)
+    update_response = BaseObject.update_info(test_object, data=data, params=params, headers=headers)
     mock_box_session.put.assert_called_once_with(expected_url, data=json.dumps(data), params=params, headers=headers)
     assert isinstance(update_response, test_object.__class__)
     assert update_response.object_id == test_object.object_id
@@ -78,7 +78,7 @@ def test_getattr_and_getitem(test_object_and_response, mock_box_session):
     # pylint:disable=redefined-outer-name, protected-access
     test_object, mock_object_response = test_object_and_response
     mock_box_session.put.return_value = mock_object_response
-    update_response = BaseObject.update_info(test_object, {})
+    update_response = BaseObject.update_info(test_object, data={})
     assert isinstance(update_response, test_object.__class__)
     assert update_response.object_id == update_response.id == update_response['id']  # pylint:disable=no-member
 

--- a/test/unit/object/test_item.py
+++ b/test/unit/object/test_item.py
@@ -24,7 +24,7 @@ def test_update_info(test_item_and_response, mock_box_session, etag, if_match_he
     expected_url = test_item.get_url()
     mock_box_session.put.return_value = mock_item_response
     data = {'foo': 'bar', 'baz': {'foo': 'bar'}, 'num': 4}
-    update_response = test_item.update_info(data, etag=etag)
+    update_response = test_item.update_info(data=data, etag=etag)
     mock_box_session.put.assert_called_once_with(expected_url, data=json.dumps(data), headers=if_match_header, params=None)
     assert isinstance(update_response, test_item.__class__)
     assert update_response.object_id == test_item.object_id
@@ -38,7 +38,7 @@ def test_update_info_with_default_request_kwargs(test_item_and_response, mock_bo
     mock_box_session_2.put.return_value = mock_item_response
     data = {'foo': 'bar', 'baz': {'foo': 'bar'}, 'num': 4}
     extra_network_parameters = {'timeout': 1}
-    update_response = test_item.update_info(data, extra_network_parameters=extra_network_parameters)
+    update_response = test_item.update_info(data=data, extra_network_parameters=extra_network_parameters)
     mock_box_session.with_default_network_request_kwargs.assert_called_once_with({'timeout': 1})
     mock_box_session_2.put.assert_called_once_with(expected_url, data=json.dumps(data), headers=None, params=None)
     assert isinstance(update_response, test_item.__class__)
@@ -154,7 +154,7 @@ def test_get(test_item_and_response, mock_box_session, fields, mock_object_id, e
     expected_url = test_item.get_url()
     mock_box_session.get.return_value = mock_item_response
     expected_params = {'fields': ','.join(fields)} if fields else None
-    info = test_item.get(fields, etag=etag)
+    info = test_item.get(fields=fields, etag=etag)
     mock_box_session.get.assert_called_once_with(expected_url, params=expected_params, headers=if_none_match_header)
     assert isinstance(info, test_item.__class__)
     assert info.id == mock_object_id

--- a/test/unit/object/test_metadata_template.py
+++ b/test/unit/object/test_metadata_template.py
@@ -144,9 +144,9 @@ def test_update_info(test_metadata_template, mock_box_session):
         'templateKey': 'vContract',
     }
 
-    updated_template = test_metadata_template.update_info(updates)
+    updated_template = test_metadata_template.update_info(updates=updates)
 
-    mock_box_session.put.assert_called_once_with(expected_url, data=json.dumps(expected_body))
+    mock_box_session.put.assert_called_once_with(expected_url, data=json.dumps(expected_body), headers=None, params=None)
     assert isinstance(updated_template, MetadataTemplate)
     assert updated_template.hidden is False
     assert updated_template.object_id is None

--- a/test/unit/object/test_retention_policy.py
+++ b/test/unit/object/test_retention_policy.py
@@ -36,7 +36,7 @@ def test_update(test_retention_policy, mock_box_session):
     data = {
         'policy_name': new_policy_name,
     }
-    retention_policy = test_retention_policy.update_info(data)
+    retention_policy = test_retention_policy.update_info(data=data)
     mock_box_session.put.assert_called_once_with(expected_url, data=json.dumps(data), headers=None, params=None)
     assert isinstance(retention_policy, RetentionPolicy)
     assert retention_policy['type'] == test_retention_policy.object_type

--- a/test/unit/object/test_storage_policy_assignment.py
+++ b/test/unit/object/test_storage_policy_assignment.py
@@ -34,7 +34,7 @@ def test_update(test_storage_policy_assignment, mock_box_session):
         'type': 'storage_policy_assignment',
         'id': new_policy_id,
     }
-    storage_policy_assignment = test_storage_policy_assignment.update_info({
+    storage_policy_assignment = test_storage_policy_assignment.update_info(data={
         'storage_policy': {
             'type': 'storage_policy',
             'id': new_policy_id,

--- a/test/unit/object/test_task.py
+++ b/test/unit/object/test_task.py
@@ -49,7 +49,7 @@ def test_update(test_task, mock_box_session):
     expected_body = {
         'message': new_message,
     }
-    updated_task = test_task.update_info({'message': new_message})
+    updated_task = test_task.update_info(data={'message': new_message})
     mock_box_session.put.assert_called_once_with(expected_url, data=json.dumps(expected_body), headers=None, params=None)
     assert isinstance(updated_task, Task)
     assert updated_task.message == new_message

--- a/test/unit/object/test_task_assignment.py
+++ b/test/unit/object/test_task_assignment.py
@@ -63,7 +63,7 @@ def test_update(test_task_assignment, mock_box_session):
         'message': new_message,
         'resolution_state': resolution_state,
     }
-    updated_task_assignment = test_task_assignment.update_info({'message': new_message, 'resolution_state': resolution_state})
+    updated_task_assignment = test_task_assignment.update_info(data={'message': new_message, 'resolution_state': resolution_state})
     mock_box_session.put.assert_called_once_with(expected_url, data=json.dumps(expected_body), headers=None, params=None)
     assert isinstance(updated_task_assignment, TaskAssignment)
     assert updated_task_assignment.message == new_message

--- a/test/unit/object/test_terms_of_service.py
+++ b/test/unit/object/test_terms_of_service.py
@@ -34,7 +34,7 @@ def test_update(test_terms_of_service, mock_box_session):
     data = {
         'text': new_text,
     }
-    updated_terms_of_service = test_terms_of_service.update_info(data)
+    updated_terms_of_service = test_terms_of_service.update_info(data=data)
     mock_box_session.put.assert_called_once_with(expected_url, data=json.dumps(data), headers=None, params=None)
     assert isinstance(updated_terms_of_service, TermsOfService)
     assert updated_terms_of_service.text == new_text

--- a/test/unit/object/test_user.py
+++ b/test/unit/object/test_user.py
@@ -79,7 +79,7 @@ def test_update(mock_user, mock_box_session):
         'name': 'New User',
     }
     mock_box_session.put.return_value.json.return_value = user
-    new_user = mock_user.update_info(data)
+    new_user = mock_user.update_info(data=data)
     mock_box_session.put.assert_called_once_with(expected_url, data=json.dumps(data), headers=None, params=None)
     assert new_user.id == user['id']
     assert new_user.type == user['type']

--- a/test/unit/object/test_web_link.py
+++ b/test/unit/object/test_web_link.py
@@ -39,7 +39,7 @@ def test_update(mock_box_session, test_web_link):
         'url': 'https://newtest.com',
     }
     mock_box_session.put.return_value.json.return_value = mock_web_link
-    web_link = test_web_link.update_info(data)
+    web_link = test_web_link.update_info(data=data)
     mock_box_session.put.assert_called_once_with(expected_url, data=json.dumps(data), headers=None, params=None)
     assert web_link.id == mock_web_link['id']
     assert web_link.type == mock_web_link['type']

--- a/test/unit/object/test_webhook.py
+++ b/test/unit/object/test_webhook.py
@@ -60,7 +60,7 @@ def test_update(test_webhook, mock_box_session):
         'address': 'https://testnotification.com',
         'triggers': ['FILE.DOWNLOADED'],
     }
-    webhook = test_webhook.update_info(data)
+    webhook = test_webhook.update_info(data=data)
     mock_box_session.put.assert_called_once_with(expected_url, data=json.dumps(data), headers=None, params=None)
     assert isinstance(webhook, Webhook)
     assert webhook.type == test_webhook.object_type


### PR DESCRIPTION
BREAKING CHANGE: Enforcing using keyword only arguments in functions :
  - `copy()` in `base_item.py` `file.py`
  - `create_shared_link()` in `item.py`, `web_link.py`
  - `get_shared_link()` in `item.py`, `web_link.py`
  - `remove_shared_link()` in `item.py`
  - `get()` in `base_object.py`, `item.py`
  - `update_info()` in `base_object.py`, `collaboration.py`, `item.py`, `metadata_template.py`
  - `delete()` in `base_object.py`, `folder.py`, `item.py`, `user.py`
Closes: SDK-1904