### PR TITLE
docs: Update URL's in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -87,7 +87,10 @@ def main():
         long_description=open(join(base_dir, 'README.rst'), encoding='utf-8').read(),  # pylint:disable=consider-using-with
         author='Box',
         author_email='oss@box.com',
-        url='http://opensource.box.com',
+        url='https://github.com/box/box-python-sdk',
+        project_urls={
+            'Changelog': 'https://github.com/box/box-python-sdk/blob/main/HISTORY.rst',
+        },
         packages=find_packages(exclude=['demo', 'docs', 'test', 'test*', '*test', '*test*']),
         install_requires=install_requires,
         extras_require=extra_requires,


### PR DESCRIPTION
* Switch the main URL to the GitHub repo. The opensource home page isn't particularly useful - when coming from PyPI, I'm already interested in this specific project.
* Add a changelog link - PyPI will render this in the sidebar with a special link, as at e.g. https://pypi.org/project/django-htmx/ . This helps when upgrading - I normally visit PyPI page and hunt for the changelog link so I can read about changes.