### PR TITLE
test: Remove mock dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,6 @@ def main():
     test_requires = [
         'bottle',
         'jsonpatch>1.14',
-        'mock>=2.0.0, <4.0.0',
         'pycodestyle',
         'pylint',
         'sphinx',

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -3,8 +3,8 @@
 import json
 import logging
 import sys
+from unittest.mock import Mock
 
-from mock import Mock
 import pytest
 import requests
 

--- a/test/functional/conftest.py
+++ b/test/functional/conftest.py
@@ -2,12 +2,12 @@
 from urllib import parse
 from test.functional.mock_box.box import Box
 from test.util.streamable_mock_open import streamable_mock_open
+from unittest.mock import patch
 
 import re
 import pytest
 import requests
 
-from mock import patch
 from boxsdk.auth.oauth2 import OAuth2
 from boxsdk.client import LoggingClient
 from boxsdk.config import API

--- a/test/functional/test_delete.py
+++ b/test/functional/test_delete.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 from test.util.streamable_mock_open import streamable_mock_open
-from mock import patch
+from unittest.mock import patch
 
 import pytest
 

--- a/test/functional/test_file_upload_update_download.py
+++ b/test/functional/test_file_upload_update_download.py
@@ -2,7 +2,7 @@
 from test.util.streamable_mock_open import streamable_mock_open
 
 from io import BytesIO
-from mock import patch
+from unittest.mock import patch
 
 
 def test_upload_then_update(box_client, test_file_path, test_file_content, update_file_content, file_name):

--- a/test/functional/test_rate_limits.py
+++ b/test/functional/test_rate_limits.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 
-from mock import patch
+from unittest.mock import patch
 
 
 def test_too_many_requests_causes_retry(box_client, mock_box, monkeypatch):

--- a/test/integration/conftest.py
+++ b/test/integration/conftest.py
@@ -1,6 +1,7 @@
 # coding: utf-8
 
-from mock import Mock
+from unittest.mock import Mock
+
 import pytest
 
 from boxsdk import Client

--- a/test/integration/mock_network.py
+++ b/test/integration/mock_network.py
@@ -1,6 +1,7 @@
 # coding: utf-8
 
-from mock import Mock
+from unittest.mock import Mock
+
 import requests
 from boxsdk.network.default_network import DefaultNetworkResponse
 from boxsdk.network.network_interface import Network

--- a/test/integration/test_as_user.py
+++ b/test/integration/test_as_user.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 
-from mock import call
+from unittest.mock import call
 import pytest
 from boxsdk.config import API, Client
 from boxsdk.object.user import User

--- a/test/integration/test_retry_and_refresh.py
+++ b/test/integration/test_retry_and_refresh.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 
-from mock import ANY, call
+from unittest.mock import ANY, call
 from boxsdk.config import API
 
 

--- a/test/integration/test_with_shared_link.py
+++ b/test/integration/test_with_shared_link.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 
-from mock import call
+from unittest.mock import call
 import pytest
 from boxsdk.config import API, Client
 from boxsdk.util.shared_link import get_shared_link_header

--- a/test/unit/auth/test_cooperatively_managed_oauth2.py
+++ b/test/unit/auth/test_cooperatively_managed_oauth2.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 
-from mock import Mock
+from unittest.mock import Mock
 
 from boxsdk.auth import cooperatively_managed_oauth2
 

--- a/test/unit/auth/test_developer_token_auth.py
+++ b/test/unit/auth/test_developer_token_auth.py
@@ -1,6 +1,7 @@
 # coding: utf-8
 
-from mock import Mock, patch
+from unittest.mock import Mock, patch
+
 from boxsdk.auth import developer_token_auth
 
 

--- a/test/unit/auth/test_jwt_auth.py
+++ b/test/unit/auth/test_jwt_auth.py
@@ -7,11 +7,11 @@ from itertools import cycle, product
 import json
 import random
 import string
+from unittest.mock import Mock, mock_open, patch, sentinel, call
 
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives.asymmetric.rsa import RSAPrivateKey, generate_private_key as generate_rsa_private_key
 from cryptography.hazmat.primitives import serialization
-from mock import Mock, mock_open, patch, sentinel, call
 import pytest
 import pytz
 import requests

--- a/test/unit/auth/test_oauth2.py
+++ b/test/unit/auth/test_oauth2.py
@@ -3,10 +3,10 @@
 from functools import partial
 import re
 from threading import Thread
+from unittest.mock import Mock, patch
 import uuid
 from urllib import parse
 
-from mock import Mock, patch
 import pytest
 
 from boxsdk.exception import BoxOAuthException

--- a/test/unit/auth/test_redis_managed_oauth2.py
+++ b/test/unit/auth/test_redis_managed_oauth2.py
@@ -1,8 +1,7 @@
 # coding: utf-8
 
+from unittest.mock import Mock, patch
 import uuid
-
-from mock import Mock, patch
 
 from boxsdk.auth import redis_managed_oauth2
 

--- a/test/unit/auth/test_remote_managed_oauth2.py
+++ b/test/unit/auth/test_remote_managed_oauth2.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 
-from mock import Mock
+from unittest.mock import Mock
 
 from boxsdk.auth import remote_managed_oauth2
 

--- a/test/unit/client/test_client.py
+++ b/test/unit/client/test_client.py
@@ -3,8 +3,8 @@
 
 import json
 from io import BytesIO
+from unittest.mock import Mock, ANY
 
-from mock import Mock, ANY
 import pytest
 
 

--- a/test/unit/conftest.py
+++ b/test/unit/conftest.py
@@ -2,8 +2,8 @@
 
 import copy
 import json
+from unittest.mock import Mock, MagicMock
 
-from mock import Mock, MagicMock
 import pytest
 
 from boxsdk.config import API, Client, Proxy

--- a/test/unit/network/conftest.py
+++ b/test/unit/network/conftest.py
@@ -1,6 +1,7 @@
 # coding: utf-8
 
-from mock import Mock
+from unittest.mock import Mock
+
 import pytest
 from requests import Session
 

--- a/test/unit/network/test_network.py
+++ b/test/unit/network/test_network.py
@@ -5,8 +5,8 @@ import json
 from logging import Logger
 from operator import attrgetter
 from pprint import pformat
+from unittest.mock import DEFAULT, Mock, patch, ANY
 
-from mock import DEFAULT, Mock, patch, ANY
 import pytest
 from requests import Response
 

--- a/test/unit/object/conftest.py
+++ b/test/unit/object/conftest.py
@@ -1,7 +1,8 @@
 # coding: utf-8
 
 import os
-from mock import Mock
+from unittest.mock import Mock
+
 import pytest
 from boxsdk.object.collaboration import Collaboration
 from boxsdk.object.collection import Collection

--- a/test/unit/object/test_chunked_upload.py
+++ b/test/unit/object/test_chunked_upload.py
@@ -4,8 +4,8 @@
 import io
 import json
 import pytest
+from unittest.mock import MagicMock, Mock, call
 
-from mock import MagicMock, Mock, call
 from boxsdk.config import API
 from boxsdk.exception import BoxAPIException
 from boxsdk.exception import BoxException

--- a/test/unit/object/test_device_pin.py
+++ b/test/unit/object/test_device_pin.py
@@ -1,8 +1,9 @@
 # coding: utf-8
 
+from unittest.mock import Mock
+
 import pytest
 
-from mock import Mock
 from boxsdk.config import API
 from boxsdk.object.device_pinner import DevicePinner
 from boxsdk.network.default_network import DefaultNetworkResponse

--- a/test/unit/object/test_events.py
+++ b/test/unit/object/test_events.py
@@ -4,9 +4,9 @@ from collections import OrderedDict
 from itertools import chain
 import json
 from typing import Optional, Union
+from unittest.mock import Mock
 from urllib.parse import urlunsplit, urlencode
 
-from mock import Mock
 import pytest
 from requests.exceptions import Timeout
 

--- a/test/unit/object/test_file.py
+++ b/test/unit/object/test_file.py
@@ -2,8 +2,8 @@
 
 import json
 from io import BytesIO
+from unittest.mock import mock_open, patch, Mock
 
-from mock import mock_open, patch, Mock
 import pytest
 from boxsdk.config import API
 from boxsdk.exception import BoxAPIException

--- a/test/unit/object/test_folder.py
+++ b/test/unit/object/test_folder.py
@@ -3,7 +3,8 @@
 import json
 from io import BytesIO
 from os.path import basename
-from mock import mock_open, patch, Mock, MagicMock
+from unittest.mock import mock_open, patch, Mock, MagicMock
+
 import pytest
 from boxsdk.config import API
 from boxsdk.exception import BoxAPIException

--- a/test/unit/object/test_group.py
+++ b/test/unit/object/test_group.py
@@ -3,8 +3,8 @@
 from itertools import chain, islice, repeat, count
 import json
 from operator import sub
+from unittest.mock import Mock
 
-from mock import Mock
 import pytest
 
 from boxsdk.network.default_network import DefaultNetworkResponse

--- a/test/unit/object/test_legal_hold_assignment.py
+++ b/test/unit/object/test_legal_hold_assignment.py
@@ -1,8 +1,8 @@
 # coding: utf-8
 
 import pytest
+from unittest.mock import Mock
 
-from mock import Mock
 from boxsdk.object.legal_hold_policy_assignment import LegalHoldPolicyAssignment
 from boxsdk.config import API
 from boxsdk.network.default_network import DefaultNetworkResponse

--- a/test/unit/object/test_legal_hold_policy.py
+++ b/test/unit/object/test_legal_hold_policy.py
@@ -1,8 +1,8 @@
 # coding: utf-8
 import json
 import pytest
+from unittest.mock import Mock
 
-from mock import Mock
 from boxsdk.object.legal_hold_policy import LegalHoldPolicy
 from boxsdk.object.legal_hold_policy_assignment import LegalHoldPolicyAssignment
 from boxsdk.config import API

--- a/test/unit/object/test_search.py
+++ b/test/unit/object/test_search.py
@@ -2,8 +2,8 @@
 
 import json
 import pytest
+from unittest.mock import ANY
 
-from mock import ANY
 from boxsdk.config import API
 from boxsdk.object.file import File
 from boxsdk.object.user import User

--- a/test/unit/object/test_storage_policy_assignment.py
+++ b/test/unit/object/test_storage_policy_assignment.py
@@ -1,8 +1,8 @@
 # coding: utf-8
 import json
 import pytest
+from unittest.mock import Mock
 
-from mock import Mock
 from boxsdk.config import API
 from boxsdk.object.storage_policy_assignment import StoragePolicyAssignment
 from boxsdk.network.default_network import DefaultNetworkResponse

--- a/test/unit/object/test_task.py
+++ b/test/unit/object/test_task.py
@@ -1,7 +1,7 @@
 import json
 import pytest
+from unittest.mock import Mock
 
-from mock import Mock
 from boxsdk.config import API
 from boxsdk.object.task import Task
 from boxsdk.object.task_assignment import TaskAssignment

--- a/test/unit/object/test_task_assignment.py
+++ b/test/unit/object/test_task_assignment.py
@@ -1,7 +1,7 @@
 import json
 import pytest
+from unittest.mock import Mock
 
-from mock import Mock
 from boxsdk.config import API
 from boxsdk.object.task_assignment import TaskAssignment, ResolutionState
 from boxsdk.network.default_network import DefaultNetworkResponse

--- a/test/unit/object/test_upload_session.py
+++ b/test/unit/object/test_upload_session.py
@@ -5,8 +5,8 @@ import hashlib
 import io
 import json
 import pytest
+from unittest.mock import patch
 
-from mock import patch
 from boxsdk.config import API
 from boxsdk.util.chunked_uploader import ChunkedUploader
 from boxsdk.object.file import File

--- a/test/unit/object/test_user.py
+++ b/test/unit/object/test_user.py
@@ -2,8 +2,8 @@
 
 import json
 import pytest
+from unittest.mock import Mock
 
-from mock import Mock
 from boxsdk.config import API
 from boxsdk.object.email_alias import EmailAlias
 from boxsdk.object.folder import Folder

--- a/test/unit/object/test_webhook.py
+++ b/test/unit/object/test_webhook.py
@@ -1,8 +1,8 @@
 # coding: utf-8
 import json
 import pytest
+from unittest.mock import Mock
 
-from mock import Mock
 from boxsdk.config import API
 from boxsdk.network.default_network import DefaultNetworkResponse
 from boxsdk.object.webhook import Webhook

--- a/test/unit/pagination/test_limit_offset_based_object_collection.py
+++ b/test/unit/pagination/test_limit_offset_based_object_collection.py
@@ -1,8 +1,8 @@
 # coding: utf-8
 
 import json
+from unittest.mock import Mock, PropertyMock
 
-from mock import Mock, PropertyMock
 import pytest
 
 from boxsdk.network.default_network import DefaultNetworkResponse

--- a/test/unit/pagination/test_marker_based_object_collection.py
+++ b/test/unit/pagination/test_marker_based_object_collection.py
@@ -1,7 +1,8 @@
 # coding: utf-8
 
 import json
-from mock import Mock, PropertyMock, ANY
+from unittest.mock import Mock, PropertyMock, ANY
+
 import pytest
 
 from boxsdk.network.default_network import DefaultNetworkResponse

--- a/test/unit/pagination/test_page.py
+++ b/test/unit/pagination/test_page.py
@@ -1,6 +1,7 @@
 # coding: utf-8
 
-from mock import Mock, PropertyMock
+from unittest.mock import Mock, PropertyMock
+
 import pytest
 
 from boxsdk.object.file import File

--- a/test/unit/session/test_session.py
+++ b/test/unit/session/test_session.py
@@ -3,8 +3,8 @@
 from functools import partial
 from io import IOBase
 from numbers import Number
+from unittest.mock import MagicMock, Mock, PropertyMock, call, patch, ANY
 
-from mock import MagicMock, Mock, PropertyMock, call, patch, ANY
 import pytest
 
 from boxsdk.auth.oauth2 import OAuth2

--- a/test/unit/test_exception.py
+++ b/test/unit/test_exception.py
@@ -1,6 +1,7 @@
 # coding: utf-8
 
-from mock import Mock
+from unittest.mock import Mock
+
 import pytest
 
 from boxsdk.exception import BoxAPIException, BoxOAuthException

--- a/test/unit/util/test_api_call_decorator.py
+++ b/test/unit/util/test_api_call_decorator.py
@@ -1,6 +1,7 @@
 # coding: utf-8
 
-from mock import NonCallableMock
+from unittest.mock import NonCallableMock
+
 import pytest
 
 from boxsdk.object.cloneable import Cloneable

--- a/test/unit/util/test_log.py
+++ b/test/unit/util/test_log.py
@@ -2,8 +2,8 @@
 
 import io
 import logging
+from unittest.mock import mock_open, patch, Mock
 
-from mock import mock_open, patch, Mock
 import pytest
 
 import boxsdk.util.log

--- a/test/util/streamable_mock_open.py
+++ b/test/util/streamable_mock_open.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 
-from mock import mock_open
+from unittest.mock import mock_open
 
 
 def streamable_mock_open(mock=None, read_data=b''):


### PR DESCRIPTION
unittest.mock was merged into Python 3, so use that version rather than the backport package.