### PR TITLE
docs: Remove obsolete`LoggingNetwork` docs from `README`

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,17 +344,6 @@ GET https://api.box.com/2.0/users/me {'headers': {u'Authorization': u'Bearer ---
 <boxsdk.object.user.User at 0x10615b8d0>
 ```
 
-For more control over how the information is logged, use the
-`LoggingNetwork` class directly.
-
-``` pycon
-from boxsdk import Client
-from boxsdk.network.logging_network import LoggingNetwork
-
-# Use a custom logger
-client = Client(oauth, network_layer=LoggingNetwork(logger))
-```
-
 ## Developer Token Client
 
 The Box Developer Console allows for the creation of short-lived


### PR DESCRIPTION
According to Change Log documentation, logging_network support was [removed in version 2.0.0](https://github.com/box/box-python-sdk/blob/main/CHANGELOG.md#200).  README documentation was never updated to reflect this removal. This PR resolves that discrepancy between docs and changelog.