### PR TITLE
fix: Remove restriction to version <2 of `urllib3` library

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ def main():
     base_dir = dirname(__file__)
     install_requires = [
         'attrs>=17.3.0',
-        'urllib3<2',
+        'urllib3',
         'requests>=2.4.3,<3',
         'requests-toolbelt>=0.4.0',
         'python-dateutil',  # To be removed after dropping Python 3.6


### PR DESCRIPTION
Fixes https://github.com/box/box-python-sdk/issues/850

Since request 2.30 supports both urllib3 1.26+ and urllib3 2.0+ we decided to remove constraints to urllib<2. (https://github.com/psf/requests/issues/6432)