### PR TITLE
fix: fix the type annotation for the OAuth access token

### DIFF
--- a/boxsdk/auth/oauth2.py
+++ b/boxsdk/auth/oauth2.py
@@ -53,7 +53,7 @@ class OAuth2:
             store_tokens: Optional[Callable[[str, str], None]] = None,
             box_device_id: str = '0',
             box_device_name: str = '',
-            access_token: str = None,
+            access_token: Optional[str] = None,
             refresh_token: Optional[str] = None,
             session: Optional[Session] = None,
             refresh_lock: Optional[ContextManager] = None,


### PR DESCRIPTION
The type annotation for the OAuth access token is incorrect