### PR TITLE
fix: Update exception file get download URL

### DIFF
--- a/boxsdk/object/file.py
+++ b/boxsdk/object/file.py
@@ -2,6 +2,7 @@ import json
 import os
 from datetime import datetime
 from typing import TYPE_CHECKING, Optional, Tuple, Union, IO, Iterable, List, Any
+from boxsdk.exception import BoxException
 
 from boxsdk.util.datetime_formatter import normalize_date_to_rfc3339_format
 from .item import Item
@@ -177,6 +178,11 @@ class File(Item):
             expect_json_response=False,
             allow_redirects=False,
         )
+        if box_response.status_code != 302:
+            raise BoxException('Unexpected status code {0} when getting download url'.format(box_response.status_code))
+        if 'location' not in box_response.headers:
+            raise BoxException('Download URL is not present in the response.')
+
         return box_response.headers['location']
 
     @api_call

--- a/boxsdk/object/file.py
+++ b/boxsdk/object/file.py
@@ -178,8 +178,6 @@ class File(Item):
             expect_json_response=False,
             allow_redirects=False,
         )
-        if box_response.status_code != 302:
-            raise BoxException('Unexpected status code {0} when getting download url'.format(box_response.status_code))
         if 'location' not in box_response.headers:
             raise BoxException('Download URL is not present in the response.')
 

--- a/test/unit/object/test_file.py
+++ b/test/unit/object/test_file.py
@@ -8,7 +8,7 @@ import pytz
 from pytest_lazyfixture import lazy_fixture
 
 from boxsdk.config import API
-from boxsdk.exception import BoxAPIException
+from boxsdk.exception import BoxAPIException, BoxException
 from boxsdk.object.comment import Comment
 from boxsdk.object.file import File
 from boxsdk.object.file_version import FileVersion
@@ -235,6 +235,20 @@ def test_get_download_url(test_file, mock_box_session):
         allow_redirects=False
     )
     assert url == download_url
+
+
+def test_get_download_url_failed(test_file, mock_box_session):
+    expected_url = f'{API.BASE_API_URL}/files/{test_file.object_id}/content'
+    mock_box_session.get.return_value.headers = {}
+    with pytest.raises(BoxException) as exc_info:
+        test_file.get_download_url()
+    assert exc_info.value.args[0] == 'Download URL is not present in the response.'
+    mock_box_session.get.assert_called_once_with(
+        expected_url,
+        params=None,
+        expect_json_response=False,
+        allow_redirects=False
+    )
 
 
 def test_get_download_url_file_version(test_file, test_file_version, mock_box_session):


### PR DESCRIPTION
Closes: SDK-3474

I'm using the `BoxException` not `BoxAPIException` because normally, the `BoxAPIException` will parse from response body but not any custom exception.