### PR TITLE
feat: add create sign request function with different required parameters

### DIFF
--- a/boxsdk/client/client.py
+++ b/boxsdk/client/client.py
@@ -1512,8 +1512,8 @@ class Client(Cloneable):
         """
         return self.translator.get('sign_request')(session=self._session, object_id=sign_request_id)
 
-    def __create_sign_request(
     # pylint: disable=too-many-branches
+    def __create_sign_request(
             self,
             signers: Iterable,
             files: Optional[Iterable] = None,

--- a/boxsdk/client/client.py
+++ b/boxsdk/client/client.py
@@ -1513,6 +1513,7 @@ class Client(Cloneable):
         return self.translator.get('sign_request')(session=self._session, object_id=sign_request_id)
 
     def __create_sign_request(
+    # pylint: disable=too-many-branches
             self,
             signers: Iterable,
             files: Optional[Iterable] = None,

--- a/boxsdk/client/client.py
+++ b/boxsdk/client/client.py
@@ -1528,7 +1528,7 @@ class Client(Cloneable):
             is_document_preparation_needed: Optional[bool] = None,
             redirect_url: Optional[str] = None,
             declined_redirect_url: Optional[str] = None,
-            template_id: Optional[str] = None) -> dict:
+            template_id: Optional[str] = None) -> SignRequest:
         url = self._session.get_url('sign_requests')
 
         body = {
@@ -1590,7 +1590,7 @@ class Client(Cloneable):
             redirect_url: Optional[str] = None,
             declined_redirect_url: Optional[str] = None,
             template_id: Optional[str] = None,
-    ) -> dict:
+    ) -> SignRequest:
         """
         Used to create a new sign request.
 
@@ -1652,7 +1652,7 @@ class Client(Cloneable):
             redirect_url: Optional[str] = None,
             declined_redirect_url: Optional[str] = None,
             template_id: Optional[str] = None,
-    ) -> dict:
+    ) -> SignRequest:
         """
         Used to create a new sign request.
 

--- a/boxsdk/client/client.py
+++ b/boxsdk/client/client.py
@@ -1528,7 +1528,7 @@ class Client(Cloneable):
             is_document_preparation_needed: Optional[bool] = None,
             redirect_url: Optional[str] = None,
             declined_redirect_url: Optional[str] = None,
-            template_id: Optional[str] = None) -> SignRequest:
+            template_id: Optional[str] = None) -> 'SignRequest':
         url = self._session.get_url('sign_requests')
 
         body = {
@@ -1590,7 +1590,7 @@ class Client(Cloneable):
             redirect_url: Optional[str] = None,
             declined_redirect_url: Optional[str] = None,
             template_id: Optional[str] = None,
-    ) -> SignRequest:
+    ) -> 'SignRequest':
         """
         Used to create a new sign request.
 
@@ -1652,7 +1652,7 @@ class Client(Cloneable):
             redirect_url: Optional[str] = None,
             declined_redirect_url: Optional[str] = None,
             template_id: Optional[str] = None,
-    ) -> SignRequest:
+    ) -> 'SignRequest':
         """
         Used to create a new sign request.
 

--- a/docs/usage/sign_requests.md
+++ b/docs/usage/sign_requests.md
@@ -40,7 +40,7 @@ signer = {
 signers = [signer]
 parent_folder_id = '123456789'
 
-new_sign_request = client.create_sign_request_v2(signers, files, parent_folder_id)
+new_sign_request = client.create_sign_request_v2(signers, files=files, parent_folder_id=parent_folder_id)
 print(f'(Sign Request ID: {new_sign_request.id})')
 ```
 

--- a/docs/usage/sign_requests.md
+++ b/docs/usage/sign_requests.md
@@ -38,8 +38,9 @@ signer = {
     'email': 'signer@mail.com'
 }
 signers = [signer]
+parent_folder_id = '123456789'
 
-new_sign_request = client.create_sign_request_v2(signers, files)
+new_sign_request = client.create_sign_request_v2(signers, files, parent_folder_id)
 print(f'(Sign Request ID: {new_sign_request.id})')
 ```
 
@@ -51,7 +52,7 @@ signer = {
     'email': 'signer@mail.com'
 }
 
-new_sign_request = client.create_sign_request_v2(signers, template_id = '12345')
+new_sign_request = client.create_sign_request_v2(signers, template_id='12345')
 print(f'(Sign Request ID: {new_sign_request.id})')
 ```
 

--- a/docs/usage/sign_requests.md
+++ b/docs/usage/sign_requests.md
@@ -19,10 +19,13 @@ A Sign Request can refer to one or more Box Files and can be sent to one or more
 Create Sign Request
 ------------------------
 
-The [`client.create_sign_request(files, signers, parent_folder_id, prefill_tags=None, are_reminders_enabled=None, are_text_signatures_enabled=None, days_valid=None, email_message=None, email_subject=None, external_id=None, is_document_preparation_needed=None, redirect_url=None, declined_redirect_url=None, template_id=None)`][create-sign-request]
-method will create a Sign Request. You need to provide at least one file and up to 10 files (from which the signing document will be created) with at least one signer to receive the Sign Request.
+The [`client.create_sign_request_v2(signers, files=None, parent_folder_id=None, prefill_tags=None, are_reminders_enabled=None, are_text_signatures_enabled=None, days_valid=None, email_message=None, email_subject=None, external_id=None, is_document_preparation_needed=None, redirect_url=None, declined_redirect_url=None, template_id=None)`][create-sign-request]
+method will create a Sign Request. You need to provide at least one file and up to 10 files (from which the signing document will be created) or template_id of the sign request template. You need to include at least one signer that will receive the Sign Request.
+
+Example with files:
 
 <!-- sample post_sign_requests -->
+
 ```python
 source_file = {
     'id': '12345',
@@ -32,12 +35,23 @@ files = [source_file]
 
 signer = {
     'name': 'John Doe',
-    'email': 'signer@mail.com' 
+    'email': 'signer@mail.com'
 }
 signers = [signer]
 
-parent_folder_id = '123456789'
-new_sign_request = client.create_sign_request(files, signers, parent_folder_id)
+new_sign_request = client.create_sign_request_v2(signers, files)
+print(f'(Sign Request ID: {new_sign_request.id})')
+```
+
+Example with sign template
+
+```python
+signer = {
+    'name': 'John Doe',
+    'email': 'signer@mail.com'
+}
+
+new_sign_request = client.create_sign_request_v2(signers, template_id = '12345')
 print(f'(Sign Request ID: {new_sign_request.id})')
 ```
 

--- a/test/integration_new/context_managers/box_sign_request.py
+++ b/test/integration_new/context_managers/box_sign_request.py
@@ -7,7 +7,7 @@ from boxsdk.object.web_link import WebLink
 class BoxTestSignRequest:
 
     def __init__(self, *, files: Iterable, signers: Iterable, parent_folder_id: str):
-        self._sign_request = CLIENT.create_sign_request(files, signers, parent_folder_id)
+        self._sign_request = CLIENT.create_sign_request_v2(signers, files, parent_folder_id)
 
     def __enter__(self) -> WebLink:
         return self._sign_request

--- a/test/integration_new/object/sign_request_itest.py
+++ b/test/integration_new/object/sign_request_itest.py
@@ -34,7 +34,7 @@ def test_test_sign_request(parent_folder, small_file_path):
         }
         signers = [signer1, signer2]
 
-        sign_request = CLIENT.create_sign_request(
+        sign_request = CLIENT.create_sign_request_v2(
             files=files,
             signers=signers,
             parent_folder_id=parent_folder.id

--- a/test/unit/client/test_client.py
+++ b/test/unit/client/test_client.py
@@ -1858,6 +1858,7 @@ def test_create_sign_request(mock_client, mock_box_session, mock_sign_request_re
     assert new_sign_request['declined_redirect_url'] == declined_redirect_url
     assert new_sign_request['template_id'] == template_id
 
+
 def test_create_sign_request_v2(mock_client, mock_box_session, mock_sign_request_response):
     expected_url = f'{API.BASE_API_URL}/sign_requests'
     redirect_url = 'https://www.box.com/accepted'
@@ -1891,6 +1892,7 @@ def test_create_sign_request_v2(mock_client, mock_box_session, mock_sign_request
     assert new_sign_request['redirect_url'] == redirect_url
     assert new_sign_request['declined_redirect_url'] == declined_redirect_url
     assert new_sign_request['template_id'] == template_id
+
 
 def test_file_request(mock_client):
     # pylint:disable=redefined-outer-name

--- a/test/unit/client/test_client.py
+++ b/test/unit/client/test_client.py
@@ -1819,6 +1819,11 @@ def test_create_sign_request(mock_client, mock_box_session, mock_sign_request_re
     parent_folder_id = '12345'
 
     data = json.dumps({
+        'signers': [
+            {
+                'email': signer['email']
+            }
+        ],
         'source_files': [
             {
                 'id': source_file['id'],
@@ -1827,11 +1832,6 @@ def test_create_sign_request(mock_client, mock_box_session, mock_sign_request_re
             {
                 'id': source_file2['id'],
                 'type': source_file2['type']
-            }
-        ],
-        'signers': [
-            {
-                'email': signer['email']
             }
         ],
         'parent_folder':
@@ -1858,6 +1858,39 @@ def test_create_sign_request(mock_client, mock_box_session, mock_sign_request_re
     assert new_sign_request['declined_redirect_url'] == declined_redirect_url
     assert new_sign_request['template_id'] == template_id
 
+def test_create_sign_request_v2(mock_client, mock_box_session, mock_sign_request_response):
+    expected_url = f'{API.BASE_API_URL}/sign_requests'
+    redirect_url = 'https://www.box.com/accepted'
+    declined_redirect_url = 'https://www.box.com/declined'
+    template_id = '123075213-af2c8822-3ef2-4952-8557-52d69c2fe9cb'
+
+    signer = {
+        'email': 'example@gmail.com'
+    }
+    signers = [signer]
+
+    data = json.dumps({
+        'signers': [
+            {
+                'email': signer['email']
+            }
+        ],
+        'redirect_url': redirect_url,
+        'declined_redirect_url': declined_redirect_url,
+        'template_id': template_id
+    })
+    mock_box_session.post.return_value.json.return_value = mock_sign_request_response
+
+    new_sign_request = mock_client.create_sign_request_v2(
+        signers,
+        redirect_url=redirect_url, declined_redirect_url=declined_redirect_url, template_id=template_id)
+
+    mock_box_session.post.assert_called_once_with(expected_url, data=data)
+    assert isinstance(new_sign_request, SignRequest)
+    assert new_sign_request['signers'][0]['email'] == signer['email']
+    assert new_sign_request['redirect_url'] == redirect_url
+    assert new_sign_request['declined_redirect_url'] == declined_redirect_url
+    assert new_sign_request['template_id'] == template_id
 
 def test_file_request(mock_client):
     # pylint:disable=redefined-outer-name


### PR DESCRIPTION
Some of the params (`parent_folder_id` and `files`)  are no longer required since https://github.com/box/box-openapi/commit/797a90d21024acb03354328cd921c989fac36f4f