### PR TITLE
chore: Add cron job to run tests

### DIFF
--- a/.github/workflows/build-and-test-daily.yml
+++ b/.github/workflows/build-and-test-daily.yml
@@ -28,7 +28,6 @@ jobs:
           python -m pip install -e .[dev]
           python -m pip install tox-gh-actions
       - name: All Tests
-        if: startsWith(github.head_ref, 'codegen-release')
         env:
           JWT_CONFIG_BASE_64: ${{ secrets.JWT_CONFIG_BASE_64 }}
           ADMIN_USER_ID: ${{ secrets.ADMIN_USER_ID }}


### PR DESCRIPTION
- add cron job to run tests at 4:20 AM CET.
Looks like we don't need to adjust coveralls, as it should report coverage of the currently check out branch locally (tested locally - https://coveralls.io/jobs/171443357